### PR TITLE
switch to latest endpoint and improve outout for empty items arrays

### DIFF
--- a/src/trustshell/products.py
+++ b/src/trustshell/products.py
@@ -21,7 +21,7 @@ from trustshell import (
 )
 from trustshell.oidc_pkce_authcode import get_access_token
 
-ANALYSIS_ENDPOINT = f"{TRUSTIFY_URL}analysis/component"
+ANALYSIS_ENDPOINT = f"{TRUSTIFY_URL}analysis/latest/component"
 MAX_I64 = 2**63 - 1
 
 custom_theme = Theme({"warning": "magenta", "error": "bold red"})
@@ -57,7 +57,7 @@ def search(component: str, debug: bool):
         sys.exit(1)
 
     ancestor_trees = _get_roots(component)
-    if len(ancestor_trees) == 0:
+    if not ancestor_trees or len(ancestor_trees) == 0:
         console.print("No results")
         return
     for tree in ancestor_trees:


### PR DESCRIPTION
Atlas 2 now has 2.0.1 of Trustify deployed. Use the analysis/latest/component endpoint instead. It's currently not returning results, so improve the output of the command in that situation.