### PR TITLE
Debug no product results

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ pkg:oci/quay-builder-qemu-rhcos-rhel8
     └── cpe:/a:redhat:quay:3:*:el8:*
 ```
 
+Use the --latest flag to include non-latest results. The default is to filter to the latest root components in a CPE. 
+Latest is calculated by comparing the published date of the product SBOM.
+
 ### Prime the Trusify graph:
 If components are found with the trust-purl command, but they are not being linked to products with
 trust-products, it could be because the Trustify graph cache is not yet primed. In order to prime the graph

--- a/src/trustshell/products.py
+++ b/src/trustshell/products.py
@@ -23,7 +23,7 @@ from trustshell import (
 from trustshell.product_definitions import ProdDefs
 
 ANALYSIS_ENDPOINT = f"{TRUSTIFY_URL}analysis/latest/component"
-MAX_I64 = 2**63 - 1
+ANCESTOR_COUNT = 10000
 
 custom_theme = Theme({"warning": "magenta", "error": "bold red"})
 console = Console(color_system="auto", theme=custom_theme)
@@ -110,7 +110,7 @@ def _get_roots(base_purl: str) -> list[Node]:
         auth_header = {"Authorization": f"Bearer {access_token}"}
 
     request_url = (
-        f"{ANALYSIS_ENDPOINT}?ancestors={MAX_I64}&q={urlencoded(f'purl~{base_purl}@')}"
+        f"{ANALYSIS_ENDPOINT}?ancestors={ANCESTOR_COUNT}&q={urlencoded(f'purl~{base_purl}@')}"
     )
     ancestors_response = httpx.get(request_url, headers=auth_header, timeout=60.0)
     ancestors_response.raise_for_status()

--- a/src/trustshell/products.py
+++ b/src/trustshell/products.py
@@ -280,7 +280,15 @@ def _trees_with_cpes(ancestor_data: dict[str, Any]) -> list[Node]:
     _remove_duplicate_branches(base_node)
     _remove_duplicate_parent_nodes(base_node)
     first_children = _remove_root_return_children(base_node)
-    trees_with_cpes = [tree for tree in first_children if _has_cpe_node(tree)]
+    trees_with_cpes: list[Node] = []
+    for tree in first_children:
+        if not _has_cpe_node(tree):
+            for leaf in tree.leaves:
+                logger.debug(
+                    f"Found result {tree.name} with ancestor: {leaf.name} but no CPE parent"
+                )
+        else:
+            trees_with_cpes.append(tree)
     return [_remove_non_cpe_branches(tree) for tree in trees_with_cpes]
 
 


### PR DESCRIPTION
Resolves: https://github.com/RedHatProductSecurity/trustshell/issues/17

Adding some debug logging to help diagnose why a purl was returned by `trust-purl` but no results in `trust-products`:

1. In debug mode the total of results is logged eg:

```
$ uv run trust-products -d pkg:rpm/redhat/acl            
           DEBUG    [15:11:35] trustshell DEBUG Number of matches for pkg:rpm/redhat/acl: 1
```

2. Latest flag toggles all results ie:

`$ uv run trust-products pkg:rpm/redhat/acl` - Does latest filtered using `$TRUSTIFY_URL/api/v2/analysis/latest/component`

while

`$ uv run trust-products -l pkg:rpm/redhat/acl` - Returns all results using `$TRUSTIFY_URL/api/v2/analysis/component`

3. Also, whenever a result is filtered out because it doesn't have a CPE parent there is now a debug statement logging the last ancestor purl, eg:

```
$ uv run trust-products -d pkg:rpm/redhat/acl
           DEBUG    [15:11:35] trustshell DEBUG Found result pkg:rpm/redhat/acl@2.2.53-3.el8 with ancestor: pkg:oci/quay-builder-qemu-rhcos-rhel8?tag=v3.14.0-4 but no CPE parent
```