### PR TITLE
Fix unset local auth server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ pkg:oci/quay-builder-qemu-rhcos-rhel8
 Use the `--latest` flag to include non-latest results. The default is to filter to the latest root components in a CPE. 
 Latest is calculated by comparing the published date of the product SBOM.
 
+Sometimes you might find a purl which is returned by `trust-purl` but doesn't have results when using `trust-products`. In that case, it usually mean the purl was not in the set of latest SBOMs. However you can check that by doing the `trust-products` query again with `-l` flag to search the entire set of SBOMs, not filtered by latest eg:
+
+```console
+$ trust-products -l pkg:oci/quay-builder-qemu-rhcos-rhel8
+```
+
+Other times there might be no results because the purl is not linked to any product level SBOMs. You can check which components the purl is found in by searching in debug mode, eg:
+
+```console
+$ trust-products -d pkg:oci/quay-builder-qemu-rhcos-rhel8
+```
+
 ### Prime the Trustify graph:
 If components are found with the trust-purl command, but they are not being linked to products with
 trust-products, it could be because the Trustify graph cache is not yet primed. To prime the graph

--- a/src/trustshell/__init__.py
+++ b/src/trustshell/__init__.py
@@ -181,7 +181,8 @@ def get_access_token():
             return response_data["access_token"]
         code_challenge = response_data["code_challenge"]
         state = response_data["state"]
-        url = build_url(code_challenge, state)
+        auth_server = response_data["auth_server"]
+        url = build_url(code_challenge, state, auth_server)
         console.print("Open a webbrowser and go to:")
         print(url)
         return ""

--- a/src/trustshell/__init__.py
+++ b/src/trustshell/__init__.py
@@ -26,6 +26,7 @@ CONFIG_DIR = os.path.expanduser("~/.config/trustshell/")
 os.makedirs(CONFIG_DIR, exist_ok=True)
 TOKEN_FILE = os.path.join(CONFIG_DIR, "access_token.jwt")
 HEADLESS = "DISPLAY" not in os.environ
+LOCAL_AUTH_SERVER_PORT = ""
 if "LOCAL_AUTH_SERVER_PORT" in os.environ:
     LOCAL_AUTH_SERVER_PORT = os.getenv("LOCAL_AUTH_SERVER_PORT")
 

--- a/src/trustshell/oidc/oidc_pkce_authcode.py
+++ b/src/trustshell/oidc/oidc_pkce_authcode.py
@@ -22,11 +22,11 @@ CODE_CHALLENGE_METHOD = "S256"
 RESPONSE_TYPE = "code"
 GRANT_TYPE = "authorization_code"
 
-auth_endpoint = os.getenv("AUTH_ENDPOINT")
+AUTH_ENDPOINT = os.getenv("AUTH_ENDPOINT")
 HEADLESS = "DISPLAY" not in os.environ
 
-authz_endpoint = f"{auth_endpoint}/auth"
-token_endpoint = f"{auth_endpoint}/token"
+authz_endpoint = f"{AUTH_ENDPOINT}/auth"
+token_endpoint = f"{AUTH_ENDPOINT}/token"
 
 
 def gen_things():
@@ -39,7 +39,7 @@ def gen_things():
     return code_verifier, code_challenge, state
 
 
-def build_url(code_challenge, state):
+def build_url(code_challenge, state, auth_server=""):
     params = {
         "response_type": RESPONSE_TYPE,
         "client_id": CLIENT_ID,
@@ -50,6 +50,8 @@ def build_url(code_challenge, state):
         "state": state,
     }
     encoded_params = urllib.parse.urlencode(params)
+    if auth_server:
+        authz_endpoint = f"{auth_server}/auth"
     url = f"{authz_endpoint}?{encoded_params}"
     return url
 

--- a/src/trustshell/oidc/oidc_pkce_server.py
+++ b/src/trustshell/oidc/oidc_pkce_server.py
@@ -7,7 +7,7 @@ from urllib.parse import (
     urlparse,
 )
 
-from oidc_pkce_authcode import code_to_token, gen_things, get_fresh_token
+from oidc_pkce_authcode import code_to_token, gen_things, get_fresh_token, AUTH_ENDPOINT
 
 PORT = int(os.getenv("LISTEN_PORT"))
 
@@ -30,7 +30,11 @@ class Handler(SimpleHTTPRequestHandler):
         if not codes:
             # Check refresh_token on the server instance
             if not self.server.refresh_token:
-                response_data = {"code_challenge": code_challenge, "state": state}
+                response_data = {
+                    "code_challenge": code_challenge,
+                    "state": state,
+                    "auth_server": AUTH_ENDPOINT,
+                }
             else:
                 # Use the refresh_token from the server instance to get a fresh token
                 access_token, refresh_token = get_fresh_token(self.server.refresh_token)


### PR DESCRIPTION
- Fixed one bug related to having env var LOCAL_AUTH_SERVER_PORT unset.
- When using local auth server, take the auth_server url from the auth server
- Update the README with debugging strageties for "No results" response from `trust-products`

