### PR TITLE
Authz endpoint unset

### DIFF
--- a/src/trustshell/__init__.py
+++ b/src/trustshell/__init__.py
@@ -170,7 +170,7 @@ def local_http_server(code_challenge, state):
 
 def get_access_token():
     if HEADLESS or LOCAL_AUTH_SERVER_PORT:
-        logger.info(
+        logger.debug(
             f"Running in HEADLESS mode, trying OIDC PKCE flow with {REDIRECT_URI}"
         )
         # Use an existing refresh token to get a new access token

--- a/src/trustshell/oidc/oidc_pkce_authcode.py
+++ b/src/trustshell/oidc/oidc_pkce_authcode.py
@@ -25,7 +25,6 @@ GRANT_TYPE = "authorization_code"
 AUTH_ENDPOINT = os.getenv("AUTH_ENDPOINT")
 HEADLESS = "DISPLAY" not in os.environ
 
-authz_endpoint = f"{AUTH_ENDPOINT}/auth"
 token_endpoint = f"{AUTH_ENDPOINT}/token"
 
 
@@ -50,6 +49,7 @@ def build_url(code_challenge, state, auth_server=""):
         "state": state,
     }
     encoded_params = urllib.parse.urlencode(params)
+    authz_endpoint = f"{AUTH_ENDPOINT}/auth"
     if auth_server:
         authz_endpoint = f"{auth_server}/auth"
     url = f"{authz_endpoint}?{encoded_params}"


### PR DESCRIPTION
Fix this error on main:

```
> uv run trust-api analysis/latest/component -s 'cpe:/a:redhat:ai_inference_server:3.1::el9' descendants=100
[14:58:12] INFO     [14:58:12] trustshell INFO Starting the local web server on 8650. Your web browser will send the code to it.                                                                                                                                                                              __init__.py:138
Traceback (most recent call last):
  File "/home/mprpic/repos/trustshell/.venv/bin/trust-api", line 8, in <module>
    sys.exit(api())
             ~~~^^
  File "/home/mprpic/repos/trustshell/.venv/lib/python3.13/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/mprpic/repos/trustshell/.venv/lib/python3.13/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/home/mprpic/repos/trustshell/.venv/lib/python3.13/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mprpic/repos/trustshell/.venv/lib/python3.13/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/home/mprpic/repos/trustshell/src/trustshell/api.py", line 41, in api
    access_token = check_or_get_access_token()
  File "/home/mprpic/repos/trustshell/src/trustshell/__init__.py", line 109, in check_or_get_access_token
    access_token = _get_and_store_access_token()
  File "/home/mprpic/repos/trustshell/src/trustshell/__init__.py", line 128, in _get_and_store_access_token
    access_token = get_access_token()
  File "/home/mprpic/repos/trustshell/src/trustshell/__init__.py", line 196, in get_access_token
    code = local_http_server(code_challenge, state)
  File "/home/mprpic/repos/trustshell/src/trustshell/__init__.py", line 163, in local_http_server
    launch_browser(code_challenge, state)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mprpic/repos/trustshell/src/trustshell/__init__.py", line 203, in launch_browser
    url = build_url(code_challenge, state)
  File "/home/mprpic/repos/trustshell/src/trustshell/oidc/oidc_pkce_authcode.py", line 55, in build_url
    url = f"{authz_endpoint}?{encoded_params}"
             ^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'authz_endpoint' where it is not associated with a value
```