### PR TITLE
dont do special cpe matching for rhel-10

### DIFF
--- a/src/trustshell/product_definitions.py
+++ b/src/trustshell/product_definitions.py
@@ -46,7 +46,11 @@ class ProductModule(ProductBase, NodeMixin):
 class ProductStream(ProductBase, NodeMixin):
     def __init__(self, name: str, cpes: list[str] = [], active: bool = False) -> None:
         super().__init__(name)
-        self.cpes = self._filter_rhel_mainline_cpes(cpes)
+        # In rhel 10 we don't use mainline CPEs, so we need to filter them out
+        if name.startswith("rhel-") and not name.startswith("rhel-10"):
+            self.cpes = self._filter_rhel_mainline_cpes(cpes)
+        else:
+            self.cpes = cpes
         self.active = active
 
     def set_active(self, active: bool) -> None:

--- a/tests/test_product_definitions.py
+++ b/tests/test_product_definitions.py
@@ -41,6 +41,21 @@ class TestProdDefs(unittest.TestCase):
         assert len(rhel_mainline_streams) == 1
         assert rhel_mainline_streams[0].name == "rhel-9.6.z"
 
+    @patch("trustshell.product_definitions.ProdDefs.get_product_definitions_service")
+    def test_prod_defs_stream_nodes_by_cpe_rhel_10(self, mock_service):
+        mock_service.return_value = self.mock_proddefs_data
+        prod_defs = ProdDefs()
+        assert "cpe:/o:redhat:enterprise_linux:10.0" in prod_defs.stream_nodes_by_cpe
+        assert (
+            "cpe:/o:redhat:enterprise_linux_eus:10.0" in prod_defs.stream_nodes_by_cpe
+        )
+        rhel_mainline_streams = prod_defs.stream_nodes_by_cpe[
+            "cpe:/o:redhat:enterprise_linux:10.0"
+        ]
+        print([s.name for s in rhel_mainline_streams])
+        assert len(rhel_mainline_streams) == 1
+        assert rhel_mainline_streams[0].name == "rhel-10.0.z"
+
     # Expected tree structure is:
     # rhel-9.2.0.z
     # └── rhel-9
@@ -56,13 +71,13 @@ class TestProdDefs(unittest.TestCase):
     def test_prod_defs_product_trees(self, mock_service):
         mock_service.return_value = self.mock_proddefs_data
         prod_defs = ProdDefs()
-        assert len(prod_defs.product_trees) == 5
+        assert len(prod_defs.product_trees) == 6
         for tree in prod_defs.product_trees:
             render_tree(tree)
-        rhel_9_2_z_stream = prod_defs.product_trees[0]
+        rhel_9_2_z_stream = prod_defs.product_trees[1]
         assert rhel_9_2_z_stream.name == "rhel-9.2.0.z"
         _check_node_names_at_depth(rhel_9_2_z_stream, 1, ["rhel-9"])
-        quay_3_12_stream = prod_defs.product_trees[3]
+        quay_3_12_stream = prod_defs.product_trees[4]
         assert quay_3_12_stream.name == "quay-3.12"
         _check_node_names_at_depth(quay_3_12_stream, 1, ["quay-3"])
 

--- a/tests/testdata/product-definitions.json
+++ b/tests/testdata/product-definitions.json
@@ -9,6 +9,15 @@
     }
   },
   "ps_modules": {
+    "rhel-10": {
+      "public_description": "Red Hat Enterprise Linux 10",
+      "ps_update_streams": [
+        "rhel-10.0.z"
+      ],
+      "active_ps_update_streams": [
+        "rhel-10.0.z"
+      ]
+    },
     "rhel-9": {
       "public_description": "Red Hat Enterprise Linux 9",
       "ps_update_streams": [
@@ -69,6 +78,14 @@
     }
   },
   "ps_update_streams": {
+    "rhel-10.0.z": {
+      "pp_label": "rhel-10.0.z",
+      "version": "rhel-10.0.z",
+      "cpe": [
+        "cpe:/o:redhat:enterprise_linux:10.0",
+        "cpe:/o:redhat:enterprise_linux_eus:10.0"
+      ]
+    },
     "rhel-9.2.0.z": {
       "pp_label": "rhel-9.2.0.z",
       "version": "rhel-9.2.0.z",


### PR DESCRIPTION
Since RHEL-10 doesn't use a generic mainline CPE like previous RHEL versions, there is no need to filter those out where an EUS/AUS/TUS CPE is also present.