### PR TITLE
PSDEVOPS-4461 use rhel9 release graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ export AUTH_ENDPOINT="https://auth.stage.redhat.com/auth/realms/EmployeeIDP/prot
 Product Mapping:
 ```bash
 export PRODDEFS_URL="https://prodsec.pages.example.com/product-definitions/products.json"
+export RHEL_RELEASE_GRAPH_URL="https://gitlab.cee.example.com/api/v4/projects/prodsec%2Frhel-release-graph"
 export SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trustshell"
-version = "0.1.0"
+version = "0.1.1"
 description = "Command Line tool for Trustify"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,9 @@ dependencies = [
     "packageurl-python>=0.16.0",
     "pkce>=1.0.3",
     "pyjwt>=2.10.1",
+    "pyyaml>=6.0",
     "rich>=14.0.0",
+    "types-pyyaml>=6.0.12.20250809",
     "univers>=30.12.1",
 ]
 

--- a/src/trustshell/product_definitions.py
+++ b/src/trustshell/product_definitions.py
@@ -9,6 +9,7 @@ import httpx
 
 from anytree import Node, NodeMixin, LevelOrderGroupIter
 from trustshell import CONFIG_DIR, console
+from trustshell.rhel_releases import EnhancedProdDefs
 
 logger = logging.getLogger(__name__)
 
@@ -47,38 +48,19 @@ class ProductStream(ProductBase, NodeMixin):
     def __init__(self, name: str, cpes: list[str] = [], active: bool = False) -> None:
         super().__init__(name)
         # In rhel 10 we don't use mainline CPEs, so we need to filter them out
-        if name.startswith("rhel-") and not name.startswith("rhel-10"):
-            self.cpes = self._filter_rhel_mainline_cpes(cpes)
+        if name.startswith("rhel-"):
+            # Remove any single digit like cpe:/a:redhat:enterprise_linux:9::appstream
+            self.cpes = [
+                cpe
+                for cpe in cpes
+                if not re.search(r":redhat:enterprise_linux:\d:", cpe)
+            ]
         else:
             self.cpes = cpes
         self.active = active
 
     def set_active(self, active: bool) -> None:
         self.active = active
-
-    @staticmethod
-    def _filter_rhel_mainline_cpes(cpes: list[str]) -> list[str]:
-        """Special logic for RHEL streams is required because during the lifetime of a RHEL
-        release it will have the main line CPE (redhat:enterprise_linux:),
-        and also EUS/AUS/TUS CPEs depending on it's lifecycle phase. The rule here is that
-        if a stream has both main line and EUS/AUS/TUS ignore the main line one
-        (which is less specific)"""
-        cpe_set = set(cpes)
-        if len(cpe_set) <= 1:
-            return cpes
-        has_eatus = False
-        for cpe in cpes:
-            for us in "eus", "aus", "tus", "e4s":
-                if f":rhel_{us}:" in cpe:
-                    has_eatus = True
-                    break
-            if has_eatus:
-                break
-        if not has_eatus:
-            return cpes
-        return [
-            cpe for cpe in cpes if not re.search(r":redhat:enterprise_linux:\d:", cpe)
-        ]
 
 
 class ProdDefs:
@@ -141,10 +123,31 @@ class ProdDefs:
                 product_definitions = json.load(f)
         return product_definitions
 
-    def __init__(self, active_only: bool = True) -> None:
+    def __init__(
+        self,
+        active_only: bool = True,
+        rhel_git_branch: str = "main",
+        rhel_releases_path: str = "",
+    ) -> None:
         self.stream_nodes_by_cpe: dict[str, list[ProductStream]] = defaultdict(list)
         product_streams_by_name: dict[str, list[ProductStream]] = defaultdict(list)
         self.product_trees: list[NodeMixin] = []
+
+        # Initialize enhanced RHEL release data
+        self.enhanced_proddefs: Optional[EnhancedProdDefs] = None
+        if rhel_releases_path:
+            # Use local file for testing
+            try:
+                self.enhanced_proddefs = EnhancedProdDefs(
+                    git_branch=rhel_git_branch, rhel_releases_path=rhel_releases_path
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Could not initialize enhanced product definitions: {e}"
+                )
+                self.enhanced_proddefs = None
+        else:
+            self.enhanced_proddefs = self._load_rhel_release_data(rhel_git_branch)
 
         data = self.get_product_definitions_service()
 
@@ -201,6 +204,36 @@ class ProdDefs:
                         module_matches.append(module)
         return module_matches
 
+    def _load_rhel_release_data(
+        self, git_branch: str = "main", rhel_releases_path: str = ""
+    ) -> Optional[EnhancedProdDefs]:
+        """
+        Load RHEL release data from GitLab repository or local file.
+
+        Args:
+            git_branch: Git branch to use for fetching data
+            rhel_releases_path: Local file path (for testing)
+
+        Returns:
+            EnhancedProdDefs instance or None if failed
+        """
+        try:
+            enhanced_proddefs = EnhancedProdDefs(
+                git_branch=git_branch, rhel_releases_path=rhel_releases_path
+            )
+            if rhel_releases_path:
+                logger.info(
+                    f"Loaded RHEL release data from local file: {rhel_releases_path}"
+                )
+            else:
+                logger.info(
+                    f"Loaded RHEL release data from GitLab (branch: {git_branch})"
+                )
+            return enhanced_proddefs
+        except Exception as e:
+            logger.error(f"Could not load RHEL release data: {e}")
+            return None
+
     @staticmethod
     def _clean_cpe(cpe: str) -> str:
         """CPEs from SBOMs have extra characters added to them, clean them up here
@@ -226,6 +259,10 @@ class ProdDefs:
         for tree in ancestor_trees:
             for leaf in tree.leaves:
                 cleaned_leaf_name = self._clean_cpe(leaf.name)
+                # Don't try and match single digit enterprise_linux CPEs
+                if re.search(r":redhat:enterprise_linux:\d:", cleaned_leaf_name):
+                    leaf.parent = None
+                    continue
                 leaf_with_products = self._check_streams(
                     leaf, cleaned_leaf_name, keep_cpes
                 )
@@ -248,6 +285,13 @@ class ProdDefs:
     def _check_streams(self, leaf: Node, cpe: str, keep_cpes: bool) -> list[Node]:
         """Check if cpe matches exactly to any ProductStreams, if it does add the CPE as a parent
         of the stream. If more than one stream matches, create copies of the stream and leaf"""
+        # First try enhanced matching if RHEL release data is available
+        enhanced_streams = self._check_enhanced_streams(cpe)
+        if enhanced_streams:
+            return self._duplicate_leaves_and_set_parents(
+                leaf, enhanced_streams, keep_cpes
+            )
+        # Fallback to original direct matching
         if cpe not in self.stream_nodes_by_cpe:
             return []
         stream_nodes = self.stream_nodes_by_cpe[cpe]
@@ -258,6 +302,39 @@ class ProdDefs:
         return self._duplicate_leaves_and_set_parents(
             leaf, copy_of_stream_nodes, keep_cpes
         )
+
+    def _check_enhanced_streams(self, cpe: str) -> list[ProductStream]:
+        """Check if CPE matches using enhanced RHEL release data logic."""
+        if not self.enhanced_proddefs:
+            return []
+
+        # Get active streams and their CPEs
+        active_streams = set()
+        stream_cpes: dict[str, list[str]] = {}
+
+        for stream_name, stream_nodes in self.stream_nodes_by_cpe.items():
+            for stream_node in stream_nodes:
+                if stream_node.active:
+                    active_streams.add(stream_node.name)
+                    if stream_node.name not in stream_cpes:
+                        stream_cpes[stream_node.name] = []
+                    stream_cpes[stream_node.name].extend(stream_node.cpes)
+
+        # Use enhanced matching to find relevant active streams
+        matching_stream_names = self.enhanced_proddefs.enhance_cpe_matching(
+            cpe, active_streams, stream_cpes
+        )
+
+        # Return the actual ProductStream objects for the matching streams
+        result_streams = []
+        for stream_name in matching_stream_names:
+            # Find ProductStream objects with this name
+            for stream_nodes in self.stream_nodes_by_cpe.values():
+                for stream_node in stream_nodes:
+                    if stream_node.name == stream_name and stream_node.active:
+                        result_streams.append(copy.deepcopy(stream_node))
+
+        return result_streams
 
     def _check_modules(self, leaf: Node, cpe: str, keep_cpes: bool) -> list[Node]:
         """Check if the cpe matches any ProductModule"""
@@ -280,7 +357,11 @@ class ProdDefs:
             If keep_cpes=False: Returns the list of unique streams that replaced the leaf.
         """
         if not product_nodes:
-            return []
+            if keep_cpes:
+                # Keep the CPE node even if no products match
+                return [leaf]
+            else:
+                return []
 
         # Convert modules to their parent streams
         streams_to_attach: list[Any] = []
@@ -312,6 +393,37 @@ class ProdDefs:
             for stream in unique_streams:
                 stream.parent = leaf.parent
             return unique_streams
+
+    def get_all_cpes_for_rhel_stream(self, stream_name: str) -> set[str]:
+        """
+        Get all CPEs that should be associated with a given RHEL stream by traversing
+        the RHEL release graph to include related releases.
+
+        Args:
+            stream_name: The ps_update_stream name (e.g., "rhel-9.2.0.z")
+
+        Returns:
+            Set of all CPEs that should be associated with this stream
+        """
+        if not self.enhanced_proddefs:
+            # Fallback to direct stream CPEs only
+            result = set()
+            for cpe, stream_nodes in self.stream_nodes_by_cpe.items():
+                for stream_node in stream_nodes:
+                    if stream_node.name == stream_name:
+                        result.update(stream_node.cpes)
+            return result
+
+        # Get stream CPEs mapping
+        stream_cpes: dict[str, list[str]] = {}
+        for cpe, stream_nodes in self.stream_nodes_by_cpe.items():
+            for stream_node in stream_nodes:
+                if stream_node.name not in stream_cpes:
+                    stream_cpes[stream_node.name] = []
+                stream_cpes[stream_node.name].extend(stream_node.cpes)
+
+        # Use enhanced matching to get all related CPEs
+        return self.enhanced_proddefs.get_all_cpes_for_stream(stream_name, stream_cpes)
 
     def _add_ancestor(self, leaf: Node, product: Any) -> None:
         if product.parent:

--- a/src/trustshell/product_definitions.py
+++ b/src/trustshell/product_definitions.py
@@ -384,15 +384,22 @@ class ProdDefs:
 
         if keep_cpes:
             # Original behavior: set streams as children of the leaf
+            # Create copies to avoid modifying shared objects
+            stream_copies = []
             for stream in unique_streams:
-                stream.parent = leaf
+                stream_copy = copy.deepcopy(stream)
+                stream_copy.parent = leaf
+                stream_copies.append(stream_copy)
             return [leaf]
         else:
             # New behavior: replace the leaf with the streams in the tree
-            # Each stream takes the place of the leaf in the tree hierarchy
+            # Create copies to avoid modifying shared objects
+            stream_copies = []
             for stream in unique_streams:
-                stream.parent = leaf.parent
-            return unique_streams
+                stream_copy = copy.deepcopy(stream)
+                stream_copy.parent = leaf.parent
+                stream_copies.append(stream_copy)
+            return stream_copies
 
     def get_all_cpes_for_rhel_stream(self, stream_name: str) -> set[str]:
         """

--- a/src/trustshell/products.py
+++ b/src/trustshell/products.py
@@ -244,7 +244,8 @@ def _remove_root_return_children(root: Node) -> list[Node]:
 def _get_branch_signature(node: Node) -> str:
     """
     Create a unique signature for a branch structure starting from the given node.
-    The signature represents the structure and node names in the branch.
+    The signature includes the root component to ensure different components
+    with the same product mappings don't get deduplicated.
 
     Args:
         node (Node): Root node of the branch to signature
@@ -252,13 +253,18 @@ def _get_branch_signature(node: Node) -> str:
     Returns:
         str: A string signature representing the branch structure
     """
+    # Always include the root component name to prevent deduplication
+    # of different components with identical product mappings
+    root_component = node.name
+
     # Use a list to collect branch elements in pre-order traversal
-    elements = []
+    elements = [f"ROOT:{root_component}"]
 
     def traverse(current_node: Node, path: str = "") -> None:
-        # Add node name and its level in the path
-        node_sig = f"{path}{current_node.name}"
-        elements.append(node_sig)
+        # Add node name and its level in the path (skip root since it's already included)
+        if current_node != node:
+            node_sig = f"{path}{current_node.name}"
+            elements.append(node_sig)
 
         # Process children in a consistent order (sort by name)
         for i, child in enumerate(sorted(current_node.children, key=lambda x: x.name)):

--- a/src/trustshell/rhel_releases.py
+++ b/src/trustshell/rhel_releases.py
@@ -39,9 +39,10 @@ class RHELReleaseNode:
 class RHELReleaseData:
     """Parser and manager for RHEL release data from GitLab repository or local files."""
 
-    # Default GitLab repository configuration
-    DEFAULT_REPO_BASE = (
-        "https://gitlab.cee.redhat.com/api/v4/projects/prodsec%2Frhel-release-graph"
+    # GitLab repository configuration (can be overridden with RHEL_RELEASE_GRAPH_URL env var)
+    RHEL_RELEASE_GRAPH_BASE = os.environ.get(
+        "RHEL_RELEASE_GRAPH_URL",
+        "https://gitlab.cee.redhat.com/api/v4/projects/prodsec%2Frhel-release-graph",
     )
     DEFAULT_FILE_PATH = "rhel9-releases.yml"
     DEFAULT_BRANCH = "main"
@@ -124,9 +125,7 @@ class RHELReleaseData:
             # Build GitLab API URL for the file
             # URL format: /projects/:id/repository/files/:file_path/raw?ref=:branch
             encoded_file_path = self.file_path.replace("/", "%2F")
-            file_url = (
-                f"{self.DEFAULT_REPO_BASE}/repository/files/{encoded_file_path}/raw"
-            )
+            file_url = f"{self.RHEL_RELEASE_GRAPH_BASE}/repository/files/{encoded_file_path}/raw"
 
             # Load cached ETag if available
             cached_etag = self._load_cached_etag(etag_file)

--- a/src/trustshell/rhel_releases.py
+++ b/src/trustshell/rhel_releases.py
@@ -1,0 +1,505 @@
+"""
+RHEL Release Data Parser
+
+This module handles parsing RHEL release data from YAML files and provides
+functionality to match CPEs from SBOMs with active ps_update_streams based
+on release hierarchy and relationships.
+"""
+
+from collections import defaultdict, deque
+import logging
+import os
+import re
+from typing import Any, Dict, List, Set, Optional
+import httpx
+import yaml
+
+from trustshell import CONFIG_DIR
+
+logger = logging.getLogger(__name__)
+
+
+class RHELReleaseNode:
+    """Represents a RHEL release node with its metadata and relationships."""
+
+    def __init__(self, name: str, node_type: str, cpes: List[str]):
+        self.name = name
+        self.node_type = node_type  # main, eus, aus, e4s
+        # Remove any single digit like cpe:/a:redhat:enterprise_linux:9::appstream
+        self.cpes = [
+            cpe for cpe in cpes if not re.search(r":redhat:enterprise_linux:\d:", cpe)
+        ]
+        self.children: Set[str] = set()
+        self.parents: Set[str] = set()
+
+    def __repr__(self) -> str:
+        return f"RHELReleaseNode({self.name}, {self.node_type}, {len(self.cpes)} CPEs)"
+
+
+class RHELReleaseData:
+    """Parser and manager for RHEL release data from GitLab repository or local files."""
+
+    # Default GitLab repository configuration
+    DEFAULT_REPO_BASE = (
+        "https://gitlab.cee.redhat.com/api/v4/projects/prodsec%2Frhel-release-graph"
+    )
+    DEFAULT_FILE_PATH = "rhel9-releases.yml"
+    DEFAULT_BRANCH = "main"
+
+    # Cache configuration
+    CACHE_DIR = os.path.join(CONFIG_DIR, "rhel_release_cache")
+    ETAG_FILE = "rhel_releases_etag.txt"
+    DATA_FILE = "rhel_releases_data.yml"
+
+    def __init__(
+        self,
+        git_branch: str = DEFAULT_BRANCH,
+        file_path: str = DEFAULT_FILE_PATH,
+        yaml_file_path: str = "",
+    ):
+        """
+        Initialize RHEL release data from GitLab repository.
+
+        Args:
+            git_branch: Git branch to use (default: main)
+            file_path: Path to file within repository (default: rhel9-releases.yml)
+            yaml_file_path: Local file path (for testing only)
+        """
+        self.git_branch = git_branch
+        self.file_path = file_path
+        self.yaml_file_path = yaml_file_path  # Only for testing
+
+        self.nodes: Dict[str, RHELReleaseNode] = {}
+        self.cpe_to_nodes: Dict[str, List[RHELReleaseNode]] = defaultdict(list)
+
+        # Ensure cache directory exists
+        os.makedirs(self.CACHE_DIR, exist_ok=True)
+
+        self._load_release_data()
+
+    def _load_release_data(self) -> None:
+        """Load and parse the RHEL release YAML file from GitLab or local file."""
+        try:
+            # Use local file if provided (for testing)
+            if self.yaml_file_path:
+                data = self._load_from_local_file()
+            else:
+                data = self._fetch_from_gitlab()
+
+            if not data:
+                logger.warning("No RHEL release data could be loaded")
+                return
+
+            self._parse_yaml_data(data)
+
+        except Exception as e:
+            logger.error(f"Error loading RHEL release data: {e}")
+
+    def _load_from_local_file(self) -> Optional[Dict[str, Any]]:
+        """Load YAML data from local file (for testing)."""
+        if not os.path.exists(self.yaml_file_path):
+            logger.warning(f"RHEL release data file not found: {self.yaml_file_path}")
+            return None
+
+        try:
+            with open(self.yaml_file_path, "r") as f:
+                data = yaml.safe_load(f)
+                if isinstance(data, dict):
+                    return data
+                else:
+                    logger.error(
+                        f"YAML file {self.yaml_file_path} does not contain a dictionary"
+                    )
+                    return None
+        except yaml.YAMLError as e:
+            logger.error(f"Failed to parse YAML file {self.yaml_file_path}: {e}")
+            return None
+
+    def _fetch_from_gitlab(self) -> Optional[Dict[str, Any]]:
+        """Fetch YAML data from GitLab repository with caching."""
+        cache_file = os.path.join(self.CACHE_DIR, self.DATA_FILE)
+        etag_file = os.path.join(self.CACHE_DIR, self.ETAG_FILE)
+
+        try:
+            # Build GitLab API URL for the file
+            # URL format: /projects/:id/repository/files/:file_path/raw?ref=:branch
+            encoded_file_path = self.file_path.replace("/", "%2F")
+            file_url = (
+                f"{self.DEFAULT_REPO_BASE}/repository/files/{encoded_file_path}/raw"
+            )
+
+            # Load cached ETag if available
+            cached_etag = self._load_cached_etag(etag_file)
+
+            # Set up headers for conditional request
+            headers = {}
+            if cached_etag:
+                headers["If-None-Match"] = cached_etag
+
+            # Make request to GitLab
+            # SSL certificate path can be set via SSL_CERT_FILE environment variable
+            ssl_cert_file = os.environ.get("SSL_CERT_FILE")
+            verify_ssl = ssl_cert_file if ssl_cert_file else True
+
+            response = httpx.get(
+                file_url,
+                params={"ref": self.git_branch},
+                headers=headers,
+                timeout=30.0,
+                verify=verify_ssl,
+            )
+
+            if response.status_code == 304:
+                # Not modified, use cached data
+                logger.info("RHEL release data not modified, using cached version")
+                return self._load_cached_data(cache_file)
+
+            elif response.status_code == 200:
+                # New data available
+                logger.info(
+                    f"Fetched RHEL release data from GitLab (branch: {self.git_branch})"
+                )
+
+                # Parse the YAML content
+                data = yaml.safe_load(response.text)
+                if not isinstance(data, dict):
+                    logger.error("YAML data from GitLab does not contain a dictionary")
+                    return None
+
+                # Cache the data and ETag
+                self._cache_data(cache_file, response.text)
+
+                # Cache ETag if provided
+                etag = response.headers.get("etag")
+                if etag:
+                    self._cache_etag(etag_file, etag)
+
+                return data
+
+            else:
+                logger.error(
+                    f"Failed to fetch RHEL release data: {response.status_code} {response.reason_phrase}"
+                )
+                # Try to use cached data as fallback
+                return self._load_cached_data(cache_file)
+
+        except httpx.RequestError as e:
+            logger.error(f"Network error fetching RHEL release data: {e}")
+            # Try to use cached data as fallback
+            return self._load_cached_data(cache_file)
+        except yaml.YAMLError as e:
+            logger.error(f"Failed to parse YAML from GitLab: {e}")
+            return None
+
+    def _load_cached_etag(self, etag_file: str) -> Optional[str]:
+        """Load cached ETag value."""
+        try:
+            if os.path.exists(etag_file):
+                with open(etag_file, "r") as f:
+                    return f.read().strip()
+        except Exception as e:
+            logger.debug(f"Could not load cached ETag: {e}")
+        return None
+
+    def _cache_etag(self, etag_file: str, etag: str) -> None:
+        """Cache ETag value."""
+        try:
+            with open(etag_file, "w") as f:
+                f.write(etag)
+        except Exception as e:
+            logger.debug(f"Could not cache ETag: {e}")
+
+    def _load_cached_data(self, cache_file: str) -> Optional[Dict[str, Any]]:
+        """Load cached YAML data."""
+        try:
+            if os.path.exists(cache_file):
+                with open(cache_file, "r") as f:
+                    data = yaml.safe_load(f)
+                    if isinstance(data, dict):
+                        return data
+                    else:
+                        logger.debug(f"Cached data in {cache_file} is not a dictionary")
+        except Exception as e:
+            logger.debug(f"Could not load cached data: {e}")
+        return None
+
+    def _cache_data(self, cache_file: str, content: str) -> None:
+        """Cache YAML data."""
+        try:
+            with open(cache_file, "w") as f:
+                f.write(content)
+        except Exception as e:
+            logger.debug(f"Could not cache data: {e}")
+
+    def _parse_yaml_data(self, data: Dict[str, Any]) -> None:
+        """Parse YAML data and build node structures."""
+        # Load nodes
+        if "nodes" in data:
+            for node_name, node_data in data["nodes"].items():
+                node_type = node_data.get("type", "unknown")
+                cpes = node_data.get("cpes", [])
+
+                node = RHELReleaseNode(node_name, node_type, cpes)
+                self.nodes[node_name] = node
+
+                # Build CPE to node mapping (use node.cpes which are already filtered)
+                for cpe in node.cpes:
+                    self.cpe_to_nodes[cpe].append(node)
+
+        # Load edges (relationships)
+        if "edges" in data:
+            for parent_name, children in data["edges"].items():
+                if parent_name in self.nodes:
+                    parent_node = self.nodes[parent_name]
+                    for child_name in children:
+                        if child_name in self.nodes:
+                            parent_node.children.add(child_name)
+                            self.nodes[child_name].parents.add(parent_name)
+
+        logger.info(f"Loaded {len(self.nodes)} RHEL release nodes")
+
+    def get_leaf_nodes(self) -> List[RHELReleaseNode]:
+        """Get all leaf nodes (nodes with no children)."""
+        return [node for node in self.nodes.values() if not node.children]
+
+    def get_descendants(self, node_name: str) -> Set[str]:
+        """Get all descendants (children, grandchildren, etc.) of a node."""
+        if node_name not in self.nodes:
+            return set()
+
+        descendants = set()
+        queue = deque([node_name])
+
+        while queue:
+            current = queue.popleft()
+            if current in self.nodes:
+                for child in self.nodes[current].children:
+                    if child not in descendants:
+                        descendants.add(child)
+                        queue.append(child)
+
+        return descendants
+
+    def get_ancestors(self, node_name: str) -> Set[str]:
+        """Get all ancestors (parents, grandparents, etc.) of a node."""
+        if node_name not in self.nodes:
+            return set()
+
+        ancestors = set()
+        queue = deque([node_name])
+
+        while queue:
+            current = queue.popleft()
+            if current in self.nodes:
+                for parent in self.nodes[current].parents:
+                    if parent not in ancestors:
+                        ancestors.add(parent)
+                        queue.append(parent)
+
+        return ancestors
+
+    def find_matching_nodes_for_cpe(self, cpe: str) -> List[RHELReleaseNode]:
+        """Find all RHEL release nodes that contain the given CPE."""
+        return self.cpe_to_nodes.get(cpe, [])
+
+    def find_active_streams_for_cpe(
+        self, cpe: str, active_streams: Set[str], stream_cpes: Dict[str, List[str]]
+    ) -> Set[str]:
+        """
+        Find active ps_update_streams that should be associated with a given CPE.
+
+        This implements the rules:
+        1. If CPE matches directly to an active ps_update_stream, use it
+        2. If CPE matches to a parent node, consider it part of each leaf node
+           whose CPEs are in active streams
+
+        Args:
+            cpe: The CPE to match
+            active_streams: Set of active ps_update_stream names
+            stream_cpes: Mapping of stream names to their CPEs
+
+        Returns:
+            Set of active stream names that should be associated with this CPE
+        """
+        result_streams = set()
+
+        # TODO once we add the other fake CPEs to the rhel release graph match all rhel streams here
+        # Check if any active streams start with 'rhel-9' - if so, always use RHEL release graph
+        has_rhel9_streams = any(
+            stream_name.startswith("rhel-9") for stream_name in active_streams
+        )
+
+        if not has_rhel9_streams:
+            # For non-RHEL 9 streams, use direct matching first
+            for stream_name in active_streams:
+                if stream_name in stream_cpes:
+                    if cpe in stream_cpes[stream_name]:
+                        result_streams.add(stream_name)
+
+            # If we found direct matches for non-RHEL 9 streams, return them
+            if result_streams:
+                return result_streams
+
+        # For RHEL 9 streams or when no direct matches found, use RHEL release graph
+        matching_nodes = self.find_matching_nodes_for_cpe(cpe)
+
+        for node in matching_nodes:
+            # For each matching node, find its leaf descendants
+            descendants = self.get_descendants(node.name)
+
+            # Include the node itself if it's a leaf
+            all_candidate_nodes = descendants | {node.name}
+
+            # Check if any leaf descendants have CPEs in active streams
+            for candidate_node_name in all_candidate_nodes:
+                if candidate_node_name in self.nodes:
+                    candidate_node = self.nodes[candidate_node_name]
+
+                    # Check if this is effectively a leaf (or the original node)
+                    # and if its CPEs are represented in active streams
+                    for candidate_cpe in candidate_node.cpes:
+                        for stream_name in active_streams:
+                            if stream_name in stream_cpes:
+                                if candidate_cpe in stream_cpes[stream_name]:
+                                    result_streams.add(stream_name)
+
+        return result_streams
+
+    def get_all_cpes_for_stream(
+        self, stream_name: str, stream_cpes: Dict[str, List[str]]
+    ) -> Set[str]:
+        """
+        Get all CPEs that should be associated with a given RHEL stream by traversing
+        the release graph to find related nodes using CPE-based matching.
+
+        Args:
+            stream_name: The ps_update_stream name (e.g., "rhel-9.2.0.z")
+            stream_cpes: Mapping of stream names to their direct CPEs
+
+        Returns:
+            Set of all CPEs that should be associated with this stream
+        """
+        all_cpes = set()
+
+        # Start with the stream's direct CPEs
+        if stream_name in stream_cpes:
+            all_cpes.update(stream_cpes[stream_name])
+
+        # Use the stream's CPEs to find matching nodes in the RHEL release graph
+        if stream_name in stream_cpes:
+            matching_nodes = set()
+
+            # For each CPE in the stream, find matching nodes in the release graph
+            for cpe in stream_cpes[stream_name]:
+                nodes_for_cpe = self.find_matching_nodes_for_cpe(cpe)
+                matching_nodes.update(nodes_for_cpe)
+
+            # For each matching node, collect CPEs from the node and its ancestors
+            for node in matching_nodes:
+                # Add CPEs from this node
+                all_cpes.update(node.cpes)
+
+                # Add CPEs from ancestor nodes (parent releases)
+                ancestors = self.get_ancestors(node.name)
+                for ancestor_name in ancestors:
+                    if ancestor_name in self.nodes:
+                        all_cpes.update(self.nodes[ancestor_name].cpes)
+
+        return all_cpes
+
+    def get_node_hierarchy(self) -> str:
+        """Get a string representation of the node hierarchy for debugging."""
+        lines = []
+
+        # Find root nodes (nodes with no parents)
+        root_nodes = [node for node in self.nodes.values() if not node.parents]
+
+        def traverse(node: RHELReleaseNode, indent: int = 0) -> None:
+            prefix = "  " * indent
+            lines.append(
+                f"{prefix}{node.name} ({node.node_type}) - {len(node.cpes)} CPEs"
+            )
+
+            # Sort children for consistent output
+            for child_name in sorted(node.children):
+                if child_name in self.nodes:
+                    traverse(self.nodes[child_name], indent + 1)
+
+        for root in sorted(root_nodes, key=lambda x: x.name):
+            traverse(root)
+
+        return "\n".join(lines)
+
+
+class EnhancedProdDefs:
+    """Enhanced product definitions that incorporate RHEL release data."""
+
+    def __init__(
+        self,
+        git_branch: str = RHELReleaseData.DEFAULT_BRANCH,
+        rhel_releases_path: str = "",
+    ):
+        """
+        Initialize enhanced product definitions.
+
+        Args:
+            git_branch: Git branch to use for RHEL release data
+            rhel_releases_path: Local file path (for testing only)
+        """
+        self.rhel_releases: Optional[RHELReleaseData] = None
+
+        try:
+            # Only try to load if we have a valid file path that exists
+            if rhel_releases_path and os.path.exists(rhel_releases_path):
+                self.rhel_releases = RHELReleaseData(
+                    git_branch=git_branch, yaml_file_path=rhel_releases_path
+                )
+            elif not rhel_releases_path:
+                # No local file, try GitLab
+                self.rhel_releases = RHELReleaseData(git_branch=git_branch)
+            else:
+                logger.warning(f"RHEL release file not found: {rhel_releases_path}")
+                self.rhel_releases = None
+        except Exception as e:
+            logger.warning(f"Could not load RHEL release data: {e}")
+            self.rhel_releases = None
+
+    def enhance_cpe_matching(
+        self, cpe: str, active_streams: Set[str], stream_cpes: Dict[str, List[str]]
+    ) -> Set[str]:
+        """
+        Enhance CPE matching using RHEL release hierarchy data.
+
+        Returns the set of active streams that should be associated with the CPE.
+        """
+        if not self.rhel_releases:
+            # Fallback to direct matching only
+            result = set()
+            for stream_name in active_streams:
+                if stream_name in stream_cpes and cpe in stream_cpes[stream_name]:
+                    result.add(stream_name)
+            return result
+
+        result = self.rhel_releases.find_active_streams_for_cpe(
+            cpe, active_streams, stream_cpes
+        )
+        return result if result is not None else set()
+
+    def get_all_cpes_for_stream(
+        self, stream_name: str, stream_cpes: Dict[str, List[str]]
+    ) -> Set[str]:
+        """
+        Get all CPEs that should be associated with a given RHEL stream.
+
+        Args:
+            stream_name: The ps_update_stream name (e.g., "rhel-9.2.0.z")
+            stream_cpes: Mapping of stream names to their direct CPEs
+
+        Returns:
+            Set of all CPEs that should be associated with this stream
+        """
+        if not self.rhel_releases:
+            # Fallback to direct CPEs only
+            return set(stream_cpes.get(stream_name, []))
+
+        return self.rhel_releases.get_all_cpes_for_stream(stream_name, stream_cpes)

--- a/tests/test_product_definitions.py
+++ b/tests/test_product_definitions.py
@@ -408,11 +408,7 @@ edges:
             root = test_trees[0].root
             render_tree(root)
             assert root.name == component
-            _check_node_names_at_depth(root, 1, [cpe])
-
-            # Should NOT map to any streams since single digit CPE is filtered out
-            # from RHEL release data and falls back to module matching (which also fails)
-            assert len(root.children[0].children) == 0
+            _check_node_names_at_depth(root, 1, [])
 
         finally:
             os.unlink(rhel_yaml_path)

--- a/tests/test_product_definitions.py
+++ b/tests/test_product_definitions.py
@@ -1,15 +1,17 @@
 import json
+import tempfile
+import os
 import unittest
 from anytree import Node
 from unittest.mock import patch
 from test_products import _check_node_names_at_depth
-from trustshell.product_definitions import ProdDefs, ProductStream
+from trustshell.product_definitions import ProdDefs
 from trustshell.products import render_tree
 
 
 class TestProdDefs(unittest.TestCase):
     def setUp(self):
-        with open("tests/testdata/product-definitions.json", "r") as file:
+        with open("tests/testdata/products/product-definitions.json", "r") as file:
             self.mock_proddefs_data = json.load(file)
 
     def test_clean_cpe(self):
@@ -17,25 +19,16 @@ class TestProdDefs(unittest.TestCase):
         result = ProdDefs._clean_cpe(cpe)
         assert result == "cpe:/a:redhat:rhel_eus:9.2::appstream"
 
-    def test_filter_rhel_mainline_cpes(self):
-        mainline_cpe = "cpe:/a:redhat:enterprise_linux:9::appstream"
-        eus_cpe = "cpe:/a:redhat:rhel_eus:9.4::appstream"
-        test_cpes = [mainline_cpe, eus_cpe]
-        ps = ProductStream("test")
-        result = ps._filter_rhel_mainline_cpes(test_cpes)
-        assert mainline_cpe not in result
-        assert eus_cpe in result
-
     @patch("trustshell.product_definitions.ProdDefs.get_product_definitions_service")
     def test_prod_defs_stream_nodes_by_cpe(self, mock_service):
         mock_service.return_value = self.mock_proddefs_data
         prod_defs = ProdDefs()
         assert (
-            "cpe:/a:redhat:enterprise_linux:9::appstream"
+            "cpe:/a:redhat:enterprise_linux:9.6::appstream"
             in prod_defs.stream_nodes_by_cpe
         )
         rhel_mainline_streams = prod_defs.stream_nodes_by_cpe[
-            "cpe:/a:redhat:enterprise_linux:9::appstream"
+            "cpe:/a:redhat:enterprise_linux:9.6::appstream"
         ]
         print([s.name for s in rhel_mainline_streams])
         assert len(rhel_mainline_streams) == 1
@@ -117,49 +110,12 @@ class TestProdDefs(unittest.TestCase):
         _check_node_names_at_depth(root, 2, ["rhel-9"])
 
     @patch("trustshell.product_definitions.ProdDefs.get_product_definitions_service")
-    def test_extend_with_product_mappings_rhel_mainline_filter(self, mock_service):
-        """Tests that the mainline cpe is only matched against streams without (e)us CPEs"""
-        mock_service.return_value = self.mock_proddefs_data
-        component = "pkg:rpm/redhat/openssl"
-        component_node = Node(component)
-        cpe = "cpe:/a:redhat:enterprise_linux:9::appstream"
-        Node(cpe, parent=component_node)
-        test_trees = [component_node]
-        ProdDefs().extend_with_product_mappings(test_trees, keep_cpes=True)
-        assert len(test_trees) == 1
-        root = test_trees[0].root
-        render_tree(root)
-        assert root.name == component
-        _check_node_names_at_depth(root, 1, [cpe])
-        _check_node_names_at_depth(root, 2, ["rhel-9.6.z"])
-        _check_node_names_at_depth(root, 3, ["rhel-9"])
-
-    @patch("trustshell.product_definitions.ProdDefs.get_product_definitions_service")
-    def test_extend_with_product_mappings_rhel_mainline_filter_no_cpes(
-        self, mock_service
-    ):
-        """Tests that the mainline cpe is only matched against streams without (e)us CPEs"""
-        mock_service.return_value = self.mock_proddefs_data
-        component = "pkg:rpm/redhat/openssl"
-        component_node = Node(component)
-        cpe = "cpe:/a:redhat:enterprise_linux:9::appstream"
-        Node(cpe, parent=component_node)
-        test_trees = [component_node]
-        ProdDefs().extend_with_product_mappings(test_trees)
-        assert len(test_trees) == 1
-        root = test_trees[0].root
-        render_tree(root)
-        assert root.name == component
-        _check_node_names_at_depth(root, 1, ["rhel-9.6.z"])
-        _check_node_names_at_depth(root, 2, ["rhel-9"])
-
-    @patch("trustshell.product_definitions.ProdDefs.get_product_definitions_service")
     def test_extend_with_product_mappings_multi_products(self, mock_service):
         """Tests that duplicate CPEs return duplicates branches"""
         mock_service.return_value = self.mock_proddefs_data
         component_1 = "pkg:rpm/redhat/openssl"
         component_2 = "pkg:rpm/redhat/openssl-debug"
-        cpe = "cpe:/a:redhat:enterprise_linux:9::appstream"
+        cpe = "cpe:/a:redhat:enterprise_linux:9.6::appstream"
         component_node_1 = Node(component_1)
         Node(cpe, parent=component_node_1)
         component_node_2 = Node(component_2)
@@ -182,7 +138,7 @@ class TestProdDefs(unittest.TestCase):
         mock_service.return_value = self.mock_proddefs_data
         component_1 = "pkg:rpm/redhat/openssl"
         component_2 = "pkg:rpm/redhat/openssl-debug"
-        cpe = "cpe:/a:redhat:enterprise_linux:9::appstream"
+        cpe = "cpe:/a:redhat:enterprise_linux:9.6::appstream"
         component_node_1 = Node(component_1)
         Node(cpe, parent=component_node_1)
         component_node_2 = Node(component_2)
@@ -311,3 +267,260 @@ class TestProdDefs(unittest.TestCase):
         _check_node_names_at_depth(first_root, 2, ["quay-3", "quay-3"])
         _check_node_names_at_depth(second_root, 1, ["quay-3.13"])
         _check_node_names_at_depth(second_root, 2, ["quay-3"])
+
+    def _create_test_rhel_releases_yaml(self):
+        """Create a temporary RHEL releases YAML file for testing."""
+        test_data = """
+nodes:
+    RHEL-9.0.0.GA:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/a:redhat:enterprise_linux:9::crb
+
+    RHEL-9.0.0.Z.MAIN+EUS:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/a:redhat:enterprise_linux:9::crb
+
+    RHEL-9.0.0.Z.EUS:
+      type: eus
+      cpes:
+        - cpe:/a:redhat:rhel_eus:9.0::appstream
+        - cpe:/o:redhat:rhel_eus:9.0::baseos
+        - cpe:/a:redhat:rhel_eus:9.0::crb
+
+    RHEL-9.2.0.GA:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/a:redhat:enterprise_linux:9.2::appstream
+
+    RHEL-9.2.0.Z.EUS:
+      type: eus
+      cpes:
+        - cpe:/a:redhat:rhel_eus:9.2::appstream
+        - cpe:/o:redhat:rhel_eus:9.2::baseos
+
+edges:
+    RHEL-9.0.0.GA:
+        - RHEL-9.0.0.Z.MAIN+EUS
+    RHEL-9.0.0.Z.MAIN+EUS:
+        - RHEL-9.0.0.Z.EUS
+        - RHEL-9.2.0.GA
+    RHEL-9.2.0.GA:
+        - RHEL-9.2.0.Z.EUS
+"""
+        temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False)
+        temp_file.write(test_data)
+        temp_file.flush()
+        temp_file.close()
+        return temp_file.name
+
+    def _create_enhanced_product_definitions(self):
+        """Create product definitions with enhanced RHEL streams for testing."""
+        return {
+            "ps_modules": {
+                "rhel-9": {
+                    "public_description": "Red Hat Enterprise Linux 9",
+                    "ps_update_streams": ["rhel-9.0.0.z", "rhel-9.2.0.z"],
+                    "active_ps_update_streams": ["rhel-9.0.0.z", "rhel-9.2.0.z"],
+                }
+            },
+            "ps_update_streams": {
+                "rhel-9.0.0.z": {
+                    "pp_label": "rhel-9.0.0.z",
+                    "version": "rhel-9.0.0.z",
+                    "cpe": [
+                        "cpe:/a:redhat:rhel_eus:9.0::appstream",
+                        "cpe:/o:redhat:rhel_eus:9.0::baseos",
+                        "cpe:/a:redhat:rhel_eus:9.0::crb",
+                    ],
+                },
+                "rhel-9.2.0.z": {
+                    "pp_label": "rhel-9.2.0.z",
+                    "version": "rhel-9.2.0.z",
+                    "cpe": [
+                        "cpe:/a:redhat:rhel_eus:9.2::appstream",
+                        "cpe:/o:redhat:rhel_eus:9.2::baseos",
+                    ],
+                },
+            },
+        }
+
+    @patch("trustshell.product_definitions.ProdDefs.get_product_definitions_service")
+    def test_rhel_releases_direct_cpe_match(self, mock_service):
+        """Test that direct CPE matches work with RHEL release data."""
+        mock_service.return_value = self._create_enhanced_product_definitions()
+        rhel_yaml_path = self._create_test_rhel_releases_yaml()
+
+        try:
+            # Create ProdDefs with RHEL release data
+            prod_defs = ProdDefs(active_only=True, rhel_releases_path=rhel_yaml_path)
+
+            # Test direct CPE match
+            component = "pkg:rpm/redhat/openssl"
+            component_node = Node(component)
+            # This CPE exists directly in the rhel-9.0.0.z stream
+            cpe = "cpe:/a:redhat:rhel_eus:9.0::appstream"
+            Node(cpe, parent=component_node)
+            test_trees = [component_node]
+
+            prod_defs.extend_with_product_mappings(test_trees, keep_cpes=True)
+
+            # Verify the mapping worked
+            root = test_trees[0].root
+            render_tree(root)
+            assert root.name == component
+            _check_node_names_at_depth(root, 1, [cpe])
+            _check_node_names_at_depth(root, 2, ["rhel-9.0.0.z"])
+            _check_node_names_at_depth(root, 3, ["rhel-9"])
+
+        finally:
+            os.unlink(rhel_yaml_path)
+
+    @patch("trustshell.product_definitions.ProdDefs.get_product_definitions_service")
+    def test_rhel_releases_parent_cpe_match(self, mock_service):
+        """Test that parent CPE matches work and map to leaf streams."""
+        mock_service.return_value = self._create_enhanced_product_definitions()
+        rhel_yaml_path = self._create_test_rhel_releases_yaml()
+
+        try:
+            # Create ProdDefs with RHEL release data
+            prod_defs = ProdDefs(active_only=True, rhel_releases_path=rhel_yaml_path)
+
+            # Test parent CPE match
+            component = "pkg:rpm/redhat/httpd"
+            component_node = Node(component)
+            # This CPE appears in parent nodes (GA, MAIN+EUS) but should now be filtered out
+            # so no matches should occur with single digit CPEs
+            cpe = "cpe:/a:redhat:enterprise_linux:9::appstream"
+            Node(cpe, parent=component_node)
+            test_trees = [component_node]
+
+            prod_defs.extend_with_product_mappings(test_trees, keep_cpes=True)
+
+            # Verify that single digit CPE is now filtered out and doesn't match
+            root = test_trees[0].root
+            render_tree(root)
+            assert root.name == component
+            _check_node_names_at_depth(root, 1, [cpe])
+
+            # Should NOT map to any streams since single digit CPE is filtered out
+            # from RHEL release data and falls back to module matching (which also fails)
+            assert len(root.children[0].children) == 0
+
+        finally:
+            os.unlink(rhel_yaml_path)
+
+    @patch("trustshell.product_definitions.ProdDefs.get_product_definitions_service")
+    def test_rhel_releases_versioned_cpe_still_works(self, mock_service):
+        """Test that versioned CPEs (like 9.0::appstream) still work with RHEL release data."""
+        mock_service.return_value = self._create_enhanced_product_definitions()
+        rhel_yaml_path = self._create_test_rhel_releases_yaml()
+
+        try:
+            # Create ProdDefs with RHEL release data
+            prod_defs = ProdDefs(active_only=True, rhel_releases_path=rhel_yaml_path)
+
+            # Test versioned CPE that should work (not filtered out)
+            component = "pkg:rpm/redhat/httpd"
+            component_node = Node(component)
+            # This CPE has version (9.2) so should NOT be filtered out
+            cpe = "cpe:/a:redhat:enterprise_linux:9.2::appstream"
+            Node(cpe, parent=component_node)
+            test_trees = [component_node]
+
+            prod_defs.extend_with_product_mappings(test_trees, keep_cpes=True)
+
+            # Verify the versioned CPE can still map to streams through RHEL release data
+            root = test_trees[0].root
+            render_tree(root)
+            assert root.name == component
+            _check_node_names_at_depth(root, 1, [cpe])
+
+            # Should map to active streams since versioned CPE exists in RHEL release data
+            stream_names = [node.name for node in root.children[0].children]
+            assert "rhel-9.2.0.z" in stream_names
+
+        finally:
+            os.unlink(rhel_yaml_path)
+
+    @patch("trustshell.product_definitions.ProdDefs.get_product_definitions_service")
+    def test_rhel_releases_no_match_behavior(self, mock_service):
+        """Test behavior when CPE doesn't match any RHEL release data."""
+        mock_service.return_value = self._create_enhanced_product_definitions()
+        rhel_yaml_path = self._create_test_rhel_releases_yaml()
+
+        try:
+            # Create ProdDefs with RHEL release data
+            prod_defs = ProdDefs(active_only=True, rhel_releases_path=rhel_yaml_path)
+
+            # Test with a CPE that doesn't match RHEL release data
+            component = "pkg:rpm/unknown/package"
+            component_node = Node(component)
+            # This CPE doesn't exist in our test RHEL release data
+            cpe = "cpe:/a:unknown:product:1.0"
+            Node(cpe, parent=component_node)
+            test_trees = [component_node]
+
+            prod_defs.extend_with_product_mappings(test_trees, keep_cpes=True)
+
+            # Should fall back to module pattern matching (which should also fail)
+            # and display a warning about no matching products
+            root = test_trees[0].root
+            assert root.name == component
+            # Should still have the original CPE node
+            assert len(root.children) == 1
+            assert root.children[0].name == cpe
+            # But no product mappings should be added
+            assert len(root.children[0].children) == 0
+
+        finally:
+            os.unlink(rhel_yaml_path)
+
+    @patch("trustshell.product_definitions.ProdDefs.get_product_definitions_service")
+    def test_rhel_releases_with_missing_file(self, mock_service):
+        """Test that ProdDefs handles missing RHEL release file gracefully."""
+        mock_service.return_value = self.mock_proddefs_data
+
+        # Try to create ProdDefs with non-existent RHEL release file
+        non_existent_path = "/path/that/does/not/exist.yml"
+        prod_defs = ProdDefs(active_only=True, rhel_releases_path=non_existent_path)
+
+        # Should create enhanced_proddefs but with no RHEL release data
+        assert prod_defs.enhanced_proddefs is not None
+        assert prod_defs.enhanced_proddefs.rhel_releases is None
+
+        # Should still work normally
+        assert len(prod_defs.product_trees) > 0
+
+    @patch("trustshell.product_definitions.ProdDefs.get_product_definitions_service")
+    def test_get_all_cpes_for_rhel_stream_enhanced(self, mock_service):
+        """Test getting all CPEs for a RHEL stream using the release graph."""
+        mock_service.return_value = self._create_enhanced_product_definitions()
+        rhel_yaml_path = self._create_test_rhel_releases_yaml()
+
+        try:
+            # Test with RHEL release data
+            prod_defs = ProdDefs(active_only=True, rhel_releases_path=rhel_yaml_path)
+
+            # Get all CPEs for rhel-9.0.0.z stream
+            all_cpes = prod_defs.get_all_cpes_for_rhel_stream("rhel-9.0.0.z")
+
+            # Should include direct stream CPEs
+            assert "cpe:/a:redhat:rhel_eus:9.0::appstream" in all_cpes
+            assert "cpe:/o:redhat:rhel_eus:9.0::baseos" in all_cpes
+
+            # Should also include CPEs from related RHEL release nodes
+            # The implementation should find RHEL-9.0.0.* nodes and their ancestors
+            assert len(all_cpes) > 2  # Should be more than just the direct CPEs
+
+            print(f"Enhanced CPEs for rhel-9.0.0.z: {sorted(all_cpes)}")
+
+        finally:
+            os.unlink(rhel_yaml_path)

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -20,7 +20,7 @@ from trustshell.product_definitions import ProdDefs
 
 class TestProducts(unittest.TestCase):
     def setUp(self):
-        with open("tests/testdata/product-definitions.json", "r") as file:
+        with open("tests/testdata/products/product-definitions.json", "r") as file:
             self.mock_proddefs_data = json.load(file)
 
     def test_build_node_purl_rpm(self):

--- a/tests/test_rhel_releases.py
+++ b/tests/test_rhel_releases.py
@@ -1,0 +1,303 @@
+"""Tests for RHEL release data parsing and CPE matching functionality."""
+
+import tempfile
+import os
+from unittest.mock import patch
+
+from trustshell.rhel_releases import RHELReleaseData, EnhancedProdDefs
+from trustshell.product_definitions import ProdDefs
+
+
+def create_test_rhel_data():
+    """Create test RHEL release data similar to the actual structure."""
+    return """
+nodes:
+    RHEL-9.0.0.GA:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9.0::appstream
+        - cpe:/o:redhat:enterprise_linux:9.0::baseos
+        - cpe:/a:redhat:enterprise_linux:9.0::crb
+
+    RHEL-9.0.0.Z.MAIN+EUS:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9.0::appstream
+        - cpe:/o:redhat:enterprise_linux:9.0::baseos
+        - cpe:/a:redhat:enterprise_linux:9.0::crb
+
+    RHEL-9.0.0.Z.EUS:
+      type: eus
+      cpes:
+        - cpe:/a:redhat:rhel_eus:9.0::appstream
+        - cpe:/o:redhat:rhel_eus:9.0::baseos
+        - cpe:/a:redhat:rhel_eus:9.0::crb
+
+    RHEL-9.2.0.GA:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9.2::appstream
+        - cpe:/o:redhat:enterprise_linux:9.2::baseos
+        - cpe:/a:redhat:enterprise_linux:9.2::appstream
+
+    RHEL-9.2.0.Z.EUS:
+      type: eus
+      cpes:
+        - cpe:/a:redhat:rhel_eus:9.2::appstream
+        - cpe:/o:redhat:rhel_eus:9.2::baseos
+
+edges:
+    RHEL-9.0.0.GA:
+        - RHEL-9.0.0.Z.MAIN+EUS
+    RHEL-9.0.0.Z.MAIN+EUS:
+        - RHEL-9.0.0.Z.EUS
+        - RHEL-9.2.0.GA
+    RHEL-9.2.0.GA:
+        - RHEL-9.2.0.Z.EUS
+"""
+
+
+def create_test_product_definitions():
+    """Create test product definitions data."""
+    return {
+        "ps_modules": {
+            "rhel-9": {
+                "public_description": "Red Hat Enterprise Linux 9",
+                "ps_update_streams": ["rhel-9.0.0.z", "rhel-9.2.0.z"],
+                "active_ps_update_streams": ["rhel-9.0.0.z", "rhel-9.2.0.z"],
+                "cpe": [
+                    "cpe:/o:redhat:enterprise_linux:9",
+                    "cpe:/a:redhat:enterprise_linux:9",
+                ],
+            }
+        },
+        "ps_update_streams": {
+            "rhel-9.0.0.z": {
+                "pp_label": "rhel-9.0.0.z",
+                "version": "rhel-9.0.0.z",
+                "cpe": [
+                    "cpe:/a:redhat:rhel_eus:9.0::appstream",
+                    "cpe:/o:redhat:rhel_eus:9.0::baseos",
+                    "cpe:/a:redhat:rhel_eus:9.0::crb",
+                ],
+            },
+            "rhel-9.2.0.z": {
+                "pp_label": "rhel-9.2.0.z",
+                "version": "rhel-9.2.0.z",
+                "cpe": [
+                    "cpe:/a:redhat:rhel_eus:9.2::appstream",
+                    "cpe:/o:redhat:rhel_eus:9.2::baseos",
+                ],
+            },
+        },
+    }
+
+
+class TestRHELReleaseData:
+    """Test RHEL release data parsing."""
+
+    def test_load_rhel_data(self):
+        """Test loading RHEL release data from YAML."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(create_test_rhel_data())
+            f.flush()
+
+            try:
+                rhel_data = RHELReleaseData(yaml_file_path=f.name)
+
+                # Check nodes were loaded
+                assert len(rhel_data.nodes) == 5
+                assert "RHEL-9.0.0.GA" in rhel_data.nodes
+                assert "RHEL-9.2.0.Z.EUS" in rhel_data.nodes
+
+                # Check node types
+                assert rhel_data.nodes["RHEL-9.0.0.GA"].node_type == "main"
+                assert rhel_data.nodes["RHEL-9.0.0.Z.EUS"].node_type == "eus"
+
+                # Check CPE mappings
+                ga_node = rhel_data.nodes["RHEL-9.0.0.GA"]
+                assert "cpe:/a:redhat:enterprise_linux:9.0::appstream" in ga_node.cpes
+                assert "cpe:/o:redhat:enterprise_linux:9.0::baseos" in ga_node.cpes
+
+                # Check relationships
+                assert "RHEL-9.0.0.Z.MAIN+EUS" in ga_node.children
+                assert (
+                    "RHEL-9.0.0.GA" in rhel_data.nodes["RHEL-9.0.0.Z.MAIN+EUS"].parents
+                )
+
+            finally:
+                os.unlink(f.name)
+
+    def test_find_matching_nodes_for_cpe(self):
+        """Test finding nodes that match a specific CPE."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(create_test_rhel_data())
+            f.flush()
+
+            try:
+                rhel_data = RHELReleaseData(yaml_file_path=f.name)
+
+                # Test exact CPE match
+                matches = rhel_data.find_matching_nodes_for_cpe(
+                    "cpe:/a:redhat:enterprise_linux:9.0::appstream"
+                )
+                assert len(matches) == 2  # GA, MAIN+EUS, both have this CPE
+
+                # Test EUS-specific CPE
+                eus_matches = rhel_data.find_matching_nodes_for_cpe(
+                    "cpe:/a:redhat:rhel_eus:9.0::appstream"
+                )
+                assert len(eus_matches) == 1
+                assert eus_matches[0].name == "RHEL-9.0.0.Z.EUS"
+
+                # Test non-existent CPE
+                no_matches = rhel_data.find_matching_nodes_for_cpe("cpe:/nonexistent")
+                assert len(no_matches) == 0
+
+            finally:
+                os.unlink(f.name)
+
+    def test_get_descendants_and_ancestors(self):
+        """Test finding descendants and ancestors of nodes."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(create_test_rhel_data())
+            f.flush()
+
+            try:
+                rhel_data = RHELReleaseData(yaml_file_path=f.name)
+
+                # Test descendants
+                ga_descendants = rhel_data.get_descendants("RHEL-9.0.0.GA")
+                assert "RHEL-9.0.0.Z.MAIN+EUS" in ga_descendants
+                assert "RHEL-9.0.0.Z.EUS" in ga_descendants
+                assert "RHEL-9.2.0.GA" in ga_descendants
+                assert "RHEL-9.2.0.Z.EUS" in ga_descendants
+
+                # Test ancestors
+                eus_ancestors = rhel_data.get_ancestors("RHEL-9.0.0.Z.EUS")
+                assert "RHEL-9.0.0.Z.MAIN+EUS" in eus_ancestors
+                assert "RHEL-9.0.0.GA" in eus_ancestors
+
+            finally:
+                os.unlink(f.name)
+
+    def test_get_leaf_nodes(self):
+        """Test finding leaf nodes (nodes with no children)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(create_test_rhel_data())
+            f.flush()
+
+            try:
+                rhel_data = RHELReleaseData(yaml_file_path=f.name)
+
+                leaf_nodes = rhel_data.get_leaf_nodes()
+                leaf_names = {node.name for node in leaf_nodes}
+
+                # EUS nodes should be leaves
+                assert "RHEL-9.0.0.Z.EUS" in leaf_names
+                assert "RHEL-9.2.0.Z.EUS" in leaf_names
+
+                # GA and MAIN+EUS should not be leaves (they have children)
+                assert "RHEL-9.0.0.GA" not in leaf_names
+                assert "RHEL-9.0.0.Z.MAIN+EUS" not in leaf_names
+
+            finally:
+                os.unlink(f.name)
+
+
+class TestEnhancedProdDefs:
+    """Test enhanced product definitions with RHEL release data."""
+
+    def test_enhance_cpe_matching_direct_match(self):
+        """Test enhanced CPE matching for direct matches."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(create_test_rhel_data())
+            f.flush()
+
+            try:
+                enhanced = EnhancedProdDefs(rhel_releases_path=f.name)
+
+                active_streams = {"rhel-9.0.0.z", "rhel-9.2.0.z"}
+                stream_cpes = {
+                    "rhel-9.0.0.z": [
+                        "cpe:/a:redhat:rhel_eus:9.0::appstream",
+                        "cpe:/o:redhat:rhel_eus:9.0::baseos",
+                    ],
+                    "rhel-9.2.0.z": [
+                        "cpe:/a:redhat:rhel_eus:9.2::appstream",
+                        "cpe:/o:redhat:rhel_eus:9.2::baseos",
+                    ],
+                }
+
+                # Test direct match
+                result = enhanced.enhance_cpe_matching(
+                    "cpe:/a:redhat:rhel_eus:9.0::appstream", active_streams, stream_cpes
+                )
+                assert "rhel-9.0.0.z" in result
+                assert len(result) == 1
+
+            finally:
+                os.unlink(f.name)
+
+    def test_enhance_cpe_matching_parent_match(self):
+        """Test enhanced CPE matching for parent node matches."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(create_test_rhel_data())
+            f.flush()
+
+            try:
+                enhanced = EnhancedProdDefs(rhel_releases_path=f.name)
+
+                active_streams = {"rhel-9.0.0.z", "rhel-9.2.0.z"}
+                stream_cpes = {
+                    "rhel-9.0.0.z": [
+                        "cpe:/a:redhat:rhel_eus:9.0::appstream",
+                        "cpe:/o:redhat:rhel_eus:9.0::baseos",
+                    ],
+                    "rhel-9.2.0.z": [
+                        "cpe:/a:redhat:rhel_eus:9.2::appstream",
+                        "cpe:/o:redhat:rhel_eus:9.2::baseos",
+                    ],
+                }
+
+                # Test parent node CPE that should match leaf nodes
+                # The CPE "cpe:/a:redhat:enterprise_linux:9::appstream" appears in parent nodes
+                # and should map to active streams that have corresponding leaf CPEs
+                result = enhanced.enhance_cpe_matching(
+                    "cpe:/a:redhat:enterprise_linux:9.0::appstream",
+                    active_streams,
+                    stream_cpes,
+                )
+
+                # Should map to active streams based on leaf node relationships
+                assert len(result) >= 1
+
+            finally:
+                os.unlink(f.name)
+
+
+class TestProdDefsIntegration:
+    """Test integration with existing ProdDefs class."""
+
+    @patch("trustshell.product_definitions.ProdDefs.get_product_definitions_service")
+    def test_proddefs_with_rhel_releases(self, mock_service):
+        """Test ProdDefs integration with RHEL release data."""
+        mock_service.return_value = create_test_product_definitions()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(create_test_rhel_data())
+            f.flush()
+
+            try:
+                # Create ProdDefs with RHEL release data
+                proddefs = ProdDefs(active_only=True, rhel_releases_path=f.name)
+
+                # Verify enhanced proddefs was initialized
+                assert proddefs.enhanced_proddefs is not None
+                assert proddefs.enhanced_proddefs.rhel_releases is not None
+
+                # Verify normal functionality still works
+                assert len(proddefs.product_trees) > 0
+
+            finally:
+                os.unlink(f.name)

--- a/tests/testdata/products/product-definitions.json
+++ b/tests/testdata/products/product-definitions.json
@@ -21,11 +21,13 @@
     "rhel-9": {
       "public_description": "Red Hat Enterprise Linux 9",
       "ps_update_streams": [
+        "rhel-9.0.0.z",
         "rhel-9.2.0.z",
         "rhel-9.4.z",
         "rhel-9.6.z"
       ],
       "active_ps_update_streams": [
+        "rhel-9.0.0.z",
         "rhel-9.2.0.z",
         "rhel-9.4.z",
         "rhel-9.6.z"
@@ -113,7 +115,7 @@
       "pp_label": "rhel-9.4.z",
       "version": "rhel-9.4.z",
       "cpe": [
-        "cpe:/a:redhat:enterprise_linux:9::appstream",
+        "cpe:/a:redhat:enterprise_linux:9.4::appstream",
         "cpe:/a:redhat:rhel_eus:9.4::appstream",
         "cpe:/o:redhat:rhel_eus:9.4::baseos",
         "cpe:/a:redhat:rhel_eus:9.4::crb",
@@ -130,7 +132,7 @@
       "pp_label": "rhel-9.6.z",
       "version": "rhel-9.6.z",
       "cpe": [
-        "cpe:/a:redhat:enterprise_linux:9::appstream"
+        "cpe:/a:redhat:enterprise_linux:9.6::appstream"
       ]
     },
     "quay-3.12": {

--- a/tests/testdata/products/rhel9-releases.yml
+++ b/tests/testdata/products/rhel9-releases.yml
@@ -1,0 +1,502 @@
+nodes:
+    RHEL-9.0.0.GA:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+        - cpe:/a:redhat:enterprise_linux:9.0::appstream
+
+    RHEL-9.0.0.Z.MAIN+EUS:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+        - cpe:/a:redhat:enterprise_linux:9.0::appstream
+
+    RHEL-9.0.0.Z.EUS:
+      type: eus
+      cpes:
+        - cpe:/a:redhat:rhel_eus:9.0::appstream
+        - cpe:/a:redhat:rhel_eus:9.0::crb
+        - cpe:/a:redhat:rhel_eus:9.0::highavailability
+        - cpe:/a:redhat:rhel_eus:9.0::nfv
+        - cpe:/a:redhat:rhel_eus:9.0::realtime
+        - cpe:/a:redhat:rhel_eus:9.0::resilientstorage
+        - cpe:/a:redhat:rhel_eus:9.0::sap
+        - cpe:/a:redhat:rhel_eus:9.0::sap_hana
+        - cpe:/a:redhat:rhel_eus:9.0::supplementary
+        - cpe:/o:redhat:rhel_eus:9.0::baseos
+
+    RHEL-9.0.0.Z.E4S:
+      type: e4s
+      cpes:
+        - cpe:/a:redhat:rhel_e4s:9.0::appstream
+        - cpe:/a:redhat:rhel_e4s:9.0::highavailability
+        - cpe:/a:redhat:rhel_e4s:9.0::nfv
+        - cpe:/a:redhat:rhel_e4s:9.0::realtime
+        - cpe:/a:redhat:rhel_e4s:9.0::resilientstorage
+        - cpe:/a:redhat:rhel_e4s:9.0::sap
+        - cpe:/a:redhat:rhel_e4s:9.0::sap_hana
+        - cpe:/o:redhat:rhel_e4s:9.0::baseos
+
+    RHEL-9.1.0.GA:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+
+    RHEL-9.1.0.Z.MAIN:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+
+    RHEL-9.2.0.GA:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+        - cpe:/a:redhat:enterprise_linux:9.2::appstream
+
+    RHEL-9.2.0.Z.MAIN+EUS:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+        - cpe:/a:redhat:enterprise_linux:9.2::appstream
+
+    RHEL-9.2.0.Z.EUS:
+      type: eus
+      cpes:
+        - cpe:/a:redhat:rhel_eus:9.2::appstream
+        - cpe:/a:redhat:rhel_eus:9.2::crb
+        - cpe:/a:redhat:rhel_eus:9.2::highavailability
+        - cpe:/a:redhat:rhel_eus:9.2::nfv
+        - cpe:/a:redhat:rhel_eus:9.2::realtime
+        - cpe:/a:redhat:rhel_eus:9.2::resilientstorage
+        - cpe:/a:redhat:rhel_eus:9.2::sap
+        - cpe:/a:redhat:rhel_eus:9.2::sap_hana
+        - cpe:/a:redhat:rhel_eus:9.2::supplementary
+        - cpe:/o:redhat:rhel_eus:9.2::baseos
+
+    RHEL-9.2.0.Z.AUS:
+      type: aus
+      cpes:
+        - cpe:/a:redhat:rhel_aus:9.2::appstream
+        - cpe:/o:redhat:rhel_aus:9.2::baseos
+
+    RHEL-9.2.0.Z.E4S:
+      type: e4s
+      cpes:
+        - cpe:/a:redhat:rhel_e4s:9.2::appstream
+        - cpe:/a:redhat:rhel_e4s:9.2::highavailability
+        - cpe:/a:redhat:rhel_e4s:9.2::nfv
+        - cpe:/a:redhat:rhel_e4s:9.2::realtime
+        - cpe:/a:redhat:rhel_e4s:9.2::resilientstorage
+        - cpe:/a:redhat:rhel_e4s:9.2::sap
+        - cpe:/a:redhat:rhel_e4s:9.2::sap_hana
+        - cpe:/o:redhat:rhel_e4s:9.2::baseos
+
+    RHEL-9.3.0.GA:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+
+    RHEL-9.3.0.Z.MAIN:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+
+    RHEL-9.4.0.GA:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+        - cpe:/a:redhat:enterprise_linux:9.4::appstream
+
+    RHEL-9.4.0.Z.MAIN+EUS:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+        - cpe:/a:redhat:enterprise_linux:9.4::appstream
+
+    RHEL-9.4.0.Z.EUS:
+      type: eus
+      cpes:
+        - cpe:/a:redhat:rhel_eus:9.4::appstream
+        - cpe:/a:redhat:rhel_eus:9.4::crb
+        - cpe:/a:redhat:rhel_eus:9.4::highavailability
+        - cpe:/a:redhat:rhel_eus:9.4::nfv
+        - cpe:/a:redhat:rhel_eus:9.4::realtime
+        - cpe:/a:redhat:rhel_eus:9.4::resilientstorage
+        - cpe:/a:redhat:rhel_eus:9.4::sap
+        - cpe:/a:redhat:rhel_eus:9.4::sap_hana
+        - cpe:/a:redhat:rhel_eus:9.4::supplementary
+        - cpe:/o:redhat:rhel_eus:9.4::baseos
+
+    RHEL-9.4.0.Z.AUS:
+      type: aus
+      cpes:
+        - cpe:/a:redhat:rhel_aus:9.4::appstream
+        - cpe:/o:redhat:rhel_aus:9.4::baseos
+
+    RHEL-9.4.0.Z.E4S:
+      type: e4s
+      cpes:
+        - cpe:/a:redhat:rhel_e4s:9.4::appstream
+        - cpe:/a:redhat:rhel_e4s:9.4::highavailability
+        - cpe:/a:redhat:rhel_e4s:9.4::nfv
+        - cpe:/a:redhat:rhel_e4s:9.4::realtime
+        - cpe:/a:redhat:rhel_e4s:9.4::resilientstorage
+        - cpe:/a:redhat:rhel_e4s:9.4::sap
+        - cpe:/a:redhat:rhel_e4s:9.4::sap_hana
+        - cpe:/o:redhat:rhel_e4s:9.4::baseos
+
+    RHEL-9.5.0.GA:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+
+    RHEL-9.5.0.Z.MAIN:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+
+    RHEL-9.6.0.GA:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+        - cpe:/a:redhat:enterprise_linux:9.6::appstream
+
+    RHEL-9.6.0.Z.MAIN+EUS:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+        - cpe:/a:redhat:enterprise_linux:9.6::appstream
+
+    RHEL-9.6.0.Z.EUS:
+      type: eus
+      cpes:
+        - cpe:/a:redhat:rhel_eus:9.6::appstream
+        - cpe:/a:redhat:rhel_eus:9.6::crb
+        - cpe:/a:redhat:rhel_eus:9.6::highavailability
+        - cpe:/a:redhat:rhel_eus:9.6::nfv
+        - cpe:/a:redhat:rhel_eus:9.6::realtime
+        - cpe:/a:redhat:rhel_eus:9.6::resilientstorage
+        - cpe:/a:redhat:rhel_eus:9.6::sap
+        - cpe:/a:redhat:rhel_eus:9.6::sap_hana
+        - cpe:/a:redhat:rhel_eus:9.6::supplementary
+        - cpe:/o:redhat:rhel_eus:9.6::baseos
+
+    RHEL-9.6.0.Z.AUS:
+      type: aus
+      cpes:
+        - cpe:/a:redhat:rhel_aus:9.6::appstream
+        - cpe:/o:redhat:rhel_aus:9.6::baseos
+
+    RHEL-9.6.0.Z.E4S:
+      type: e4s
+      cpes:
+        - cpe:/a:redhat:rhel_e4s:9.6::appstream
+        - cpe:/a:redhat:rhel_e4s:9.6::highavailability
+        - cpe:/a:redhat:rhel_e4s:9.6::nfv
+        - cpe:/a:redhat:rhel_e4s:9.6::realtime
+        - cpe:/a:redhat:rhel_e4s:9.6::resilientstorage
+        - cpe:/a:redhat:rhel_e4s:9.6::sap
+        - cpe:/a:redhat:rhel_e4s:9.6::sap_hana
+        - cpe:/o:redhat:rhel_e4s:9.6::baseos
+
+    RHEL-9.7.0.GA:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+
+    RHEL-9.7.0.Z.MAIN:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/o:redhat:enterprise_linux:9::fastdatapath
+        - cpe:/o:redhat:enterprise_linux:9::hypervisor
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+
+    RHEL-9.8.0.GA:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+
+    RHEL-9.8.0.Z.MAIN+EUS:
+      type: main
+      cpes:
+        - cpe:/a:redhat:enterprise_linux:9::appstream
+        - cpe:/o:redhat:enterprise_linux:9::baseos
+        - cpe:/a:redhat:enterprise_linux:9::crb
+        - cpe:/a:redhat:enterprise_linux:9::highavailability
+        - cpe:/a:redhat:enterprise_linux:9::nfv
+        - cpe:/a:redhat:enterprise_linux:9::realtime
+        - cpe:/a:redhat:enterprise_linux:9::resilientstorage
+        - cpe:/a:redhat:enterprise_linux:9::sap
+        - cpe:/a:redhat:enterprise_linux:9::sap_hana
+        - cpe:/a:redhat:enterprise_linux:9::supplementary
+
+    RHEL-9.8.0.Z.EUS:
+      type: eus
+      cpes:
+        - cpe:/a:redhat:rhel_eus:9.8::appstream
+        - cpe:/a:redhat:rhel_eus:9.8::crb
+        - cpe:/a:redhat:rhel_eus:9.8::highavailability
+        - cpe:/a:redhat:rhel_eus:9.8::nfv
+        - cpe:/a:redhat:rhel_eus:9.8::realtime
+        - cpe:/a:redhat:rhel_eus:9.8::resilientstorage
+        - cpe:/a:redhat:rhel_eus:9.8::sap
+        - cpe:/a:redhat:rhel_eus:9.8::sap_hana
+        - cpe:/a:redhat:rhel_eus:9.8::supplementary
+        - cpe:/o:redhat:rhel_eus:9.8::baseos
+
+    RHEL-9.8.0.Z.AUS:
+      type: aus
+      cpes:
+        - cpe:/a:redhat:rhel_aus:9.8::appstream
+        - cpe:/o:redhat:rhel_aus:9.8::baseos
+
+    RHEL-9.8.0.Z.E4S:
+      type: e4s
+      cpes:
+        - cpe:/a:redhat:rhel_e4s:9.8::appstream
+        - cpe:/a:redhat:rhel_e4s:9.8::highavailability
+        - cpe:/a:redhat:rhel_e4s:9.8::nfv
+        - cpe:/a:redhat:rhel_e4s:9.8::realtime
+        - cpe:/a:redhat:rhel_e4s:9.8::resilientstorage
+        - cpe:/a:redhat:rhel_e4s:9.8::sap
+        - cpe:/a:redhat:rhel_e4s:9.8::sap_hana
+        - cpe:/o:redhat:rhel_e4s:9.8::baseos
+
+edges:
+    RHEL-9.0.0.GA:
+        - RHEL-9.0.0.Z.MAIN+EUS
+    RHEL-9.0.0.Z.MAIN+EUS:
+        - RHEL-9.0.0.Z.EUS
+        - RHEL-9.1.0.GA
+    RHEL-9.0.0.Z.EUS:
+        - RHEL-9.0.0.Z.E4S
+    RHEL-9.1.0.GA:
+        - RHEL-9.1.0.Z.MAIN
+    RHEL-9.1.0.Z.MAIN:
+        - RHEL-9.2.0.GA
+    RHEL-9.2.0.GA:
+        - RHEL-9.2.0.Z.MAIN+EUS
+    RHEL-9.2.0.Z.MAIN+EUS:
+        - RHEL-9.2.0.Z.EUS
+        - RHEL-9.3.0.GA
+    RHEL-9.2.0.Z.EUS:
+        - RHEL-9.2.0.Z.AUS
+        - RHEL-9.2.0.Z.E4S
+    RHEL-9.3.0.GA:
+        - RHEL-9.3.0.Z.MAIN
+    RHEL-9.3.0.Z.MAIN:
+        - RHEL-9.4.0.GA
+    RHEL-9.4.0.GA:
+        - RHEL-9.4.0.Z.MAIN+EUS
+    RHEL-9.4.0.Z.MAIN+EUS:
+        - RHEL-9.4.0.Z.EUS
+        - RHEL-9.5.0.GA
+    RHEL-9.4.0.Z.EUS:
+        - RHEL-9.4.0.Z.AUS
+        - RHEL-9.4.0.Z.E4S
+    RHEL-9.5.0.GA:
+        - RHEL-9.5.0.Z.MAIN
+    RHEL-9.5.0.Z.MAIN:
+        - RHEL-9.6.0.GA
+    RHEL-9.6.0.GA:
+        - RHEL-9.6.0.Z.MAIN+EUS
+    RHEL-9.6.0.Z.MAIN+EUS:
+        - RHEL-9.6.0.Z.EUS
+        - RHEL-9.7.0.GA
+    RHEL-9.6.0.Z.EUS:
+        - RHEL-9.6.0.Z.AUS
+        - RHEL-9.6.0.Z.E4S
+    RHEL-9.7.0.GA:
+        - RHEL-9.7.0.Z.MAIN
+    RHEL-9.7.0.Z.MAIN:
+        - RHEL-9.8.0.GA
+    RHEL-9.8.0.GA:
+        - RHEL-9.8.0.Z.MAIN+EUS
+    RHEL-9.8.0.Z.MAIN+EUS:
+        - RHEL-9.8.0.Z.EUS
+    RHEL-9.8.0.Z.EUS:
+        - RHEL-9.8.0.Z.AUS
+        - RHEL-9.8.0.Z.E4S

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -506,6 +506,23 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.4"
 source = { registry = "https://pypi.org/simple" }
@@ -594,7 +611,9 @@ dependencies = [
     { name = "packageurl-python" },
     { name = "pkce" },
     { name = "pyjwt" },
+    { name = "pyyaml" },
     { name = "rich" },
+    { name = "types-pyyaml" },
     { name = "univers" },
 ]
 
@@ -616,7 +635,9 @@ requires-dist = [
     { name = "packageurl-python", specifier = ">=0.16.0" },
     { name = "pkce", specifier = ">=1.0.3" },
     { name = "pyjwt", specifier = ">=2.10.1" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=14.0.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250809" },
     { name = "univers", specifier = ">=30.12.1" },
 ]
 
@@ -625,6 +646,15 @@ dev = [{ name = "pytest", specifier = ">=8.3.5" }]
 lint = [
     { name = "mypy", specifier = ">=1.0.0" },
     { name = "types-requests" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250809"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/21/52ffdbddea3c826bc2758d811ccd7f766912de009c5cf096bd5ebba44680/types_pyyaml-6.0.12.20250809.tar.gz", hash = "sha256:af4a1aca028f18e75297da2ee0da465f799627370d74073e96fee876524f61b5", size = 17385, upload-time = "2025-08-09T03:14:34.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/3e/0346d09d6e338401ebf406f12eaf9d0b54b315b86f1ec29e34f1a0aedae9/types_pyyaml-6.0.12.20250809-py3-none-any.whl", hash = "sha256:032b6003b798e7de1a1ddfeefee32fac6486bdfe4845e0ae0e7fb3ee4512b52f", size = 20277, upload-time = "2025-08-09T03:14:34.055Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This uses the Red Hat internal rhel-release-graph repository to match rhel CPEs to all relevant RHEL streams.