### PR TITLE
PSDEVOPS-4346: Enable searching for products by provenance

### DIFF
--- a/src/trustshell/__init__.py
+++ b/src/trustshell/__init__.py
@@ -192,6 +192,20 @@ def purl_sans_version(purl: PackageURL) -> PackageURL:
     return purl_sans_version
 
 
+def purl_to_bare(purl: str) -> str:
+    """Strip a PURL to type/namespace/name only (no version, no qualifiers).
+    e.g. pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=... -> pkg:rpm/redhat/python3.12
+    """
+    purl_obj = PackageURL.from_string(purl)
+    return PackageURL(
+        type=purl_obj.type,
+        namespace=purl_obj.namespace,
+        name=purl_obj.name,
+        version="",
+        qualifiers={},
+    ).to_string()
+
+
 def check_or_get_access_token() -> str:
     if not os.path.exists(TOKEN_FILE):
         logger.debug("Access token not found. Getting a new one...")

--- a/src/trustshell/products.py
+++ b/src/trustshell/products.py
@@ -18,6 +18,7 @@ from trustshell import (
     config_logging,
     print_version,
     purl_sans_version,
+    purl_to_bare,
     paginated_trustify_query,
 )
 from trustshell.models import Affect, ProductResultRow, ProductSearchResult
@@ -174,7 +175,10 @@ def search(
     versions: bool,
     include_rpm_containers: bool,
 ) -> None:
-    """Relate a purl to products in Trustify"""
+    """Relate a PURL or search term to products in Trustify.
+    If the argument is a valid PURL, it is used as-is. Otherwise it is treated
+    as a search term and resolved via the analysis/latest component API.
+    """
     if flaw and output == "json":
         raise click.UsageError("--flaw and --output are mutually exclusive.")
 
@@ -185,12 +189,28 @@ def search(
 
     try:
         PackageURL.from_string(purl)
+        resolved_purl = purl
     except ValueError:
-        console.print(f"{purl} is not a valid Package URL", style="error")
+        generic_purl = get_generic_purl_from_search_term(purl, latest)
+        if generic_purl is None:
+            console.print("No results", style="error")
+            sys.exit(1)
+        resolved_purl = get_redhat_purl_from_generic(generic_purl, latest)
+        if resolved_purl is None:
+            console.print("No results", style="error")
+            sys.exit(1)
+
+    try:
+        PackageURL.from_string(resolved_purl)
+    except ValueError:
+        console.print(
+            f"Resolved {resolved_purl!r} is not a valid Package URL",
+            style="error",
+        )
         sys.exit(1)
 
     ancestor_trees = _get_roots(
-        purl,
+        resolved_purl,
         latest,
         show_versions=versions,
         include_rpm_containers=include_rpm_containers,
@@ -201,7 +221,7 @@ def search(
         return
 
     prod_defs = ProdDefs()
-    result = build_product_search_result(ancestor_trees, prod_defs, purl, cpes=cpes)
+    result = build_product_search_result(ancestor_trees, prod_defs, resolved_purl, cpes=cpes)
 
     if flaw:
         osidb = OSIDB()
@@ -380,6 +400,77 @@ def extract_affects(ancestor_trees: list[ComponentNode]) -> set[tuple[str, str]]
                     )
                 )
     return affects
+
+
+def get_generic_purl_from_search_term(
+    search_term: str, latest: bool
+) -> Optional[str]:
+    """Query endpoint with q=<search_term>, get first result's purl, strip to bare (no version, no qualifiers)."""
+    auth_header = {}
+    if AUTH_ENABLED:
+        access_token = check_or_get_access_token()
+        auth_header = {"Authorization": f"Bearer {access_token}"}
+
+    endpoint = LATEST_ENDPOINT if latest else ANALYSIS_ENDPOINT
+    params = {"q": search_term}
+    try:
+        response = httpx.get(
+            endpoint, params=params, headers=auth_header, timeout=300
+        )
+        response.raise_for_status()
+        data = response.json()
+    except (httpx.HTTPStatusError, httpx.RequestError) as e:
+        logger.debug(f"Search term query failed: {e}")
+        return None
+
+    items = data.get("items", [])
+    if not items:
+        return None
+    first = items[0]
+    purls = first.get("purl") or []
+    if not purls:
+        return None
+    return purl_to_bare(purls[0])
+
+
+def get_redhat_purl_from_generic(
+    generic_purl: str, latest: bool
+) -> Optional[str]:
+    """Query endpoint with q=purl~<generic_purl>, descendants=10, relationships=ancestor_of;
+    get redhat PURL from items[0].descendants[0].purl[0] and strip to bare.
+    """
+    auth_header = {}
+    if AUTH_ENABLED:
+        access_token = check_or_get_access_token()
+        auth_header = {"Authorization": f"Bearer {access_token}"}
+
+    endpoint = LATEST_ENDPOINT if latest else ANALYSIS_ENDPOINT
+    params = {
+        "q": f"purl~{generic_purl}",
+        "descendants": 10,
+        "relationships": "ancestor_of",
+    }
+    try:
+        response = httpx.get(
+            endpoint, params=params, headers=auth_header, timeout=300
+        )
+        response.raise_for_status()
+        data = response.json()
+    except (httpx.HTTPStatusError, httpx.RequestError) as e:
+        logger.debug(f"Generic purl query failed: {e}")
+        return None
+
+    items = data.get("items", [])
+    if not items:
+        return None
+    first = items[0]
+    descendants = first.get("descendants") or []
+    if not descendants:
+        return None
+    purls = descendants[0].get("purl") or []
+    if not purls:
+        return None
+    return purl_to_bare(purls[0])
 
 
 def _get_roots(

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -5,12 +5,16 @@ from unittest.mock import patch
 
 from anytree import Node
 
-from trustshell import build_node_purl, render_tree
+from packageurl import PackageURL
+
+from trustshell import build_node_purl, purl_to_bare, render_tree
 from trustshell.products import (
     ComponentNode,
     _get_branch_signature,
     _remove_duplicate_parent_nodes,
     _remove_non_cpe_branches,
+    get_generic_purl_from_search_term,
+    get_redhat_purl_from_generic,
     _trees_with_cpes,
     _has_cpe_node,
     container_in_tree,
@@ -645,6 +649,104 @@ class TestProducts(unittest.TestCase):
             "cpe:/a:redhat:rhel_eus:9.2:*:baseos:*",
         ]
         _check_node_names_at_depth(result[0], 1, expected_cpes)
+
+    def test_purl_to_bare(self):
+        """purl_to_bare strips version and qualifiers."""
+        full = "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9"
+        assert purl_to_bare(full) == "pkg:rpm/redhat/python3.12"
+        assert purl_to_bare("pkg:pypi/chardet@3.0.4") == "pkg:pypi/chardet"
+        assert purl_to_bare("pkg:generic/Python@3.12.9?checksum=SHA-256:abc") == "pkg:generic/Python"
+
+    @parameterized.expand(
+        [
+            (
+                "www.python.org",
+                "www.python.org-search.json",
+                "pkg:generic/Python",
+            ),
+            (
+                "Python",
+                "www.python.org-search.json",
+                "pkg:generic/Python",
+            ),
+            (
+                "nonexistent",
+                None,
+                None,
+            ),
+        ]
+    )
+    @patch("trustshell.products.httpx.get")
+    def test_get_generic_purl_from_search_term(
+        self, search_term, data_file, expected, mock_get
+    ):
+        """get_generic_purl_from_search_term returns first result's purl stripped to bare or None."""
+        if data_file is None:
+            mock_get.return_value.json.return_value = {"items": []}
+        else:
+            with open(f"tests/testdata/{data_file}") as f:
+                mock_get.return_value.json.return_value = json.load(f)
+        mock_get.return_value.raise_for_status = lambda: None
+        result = get_generic_purl_from_search_term(search_term, latest=True)
+        assert result == expected
+        mock_get.assert_called_once()
+        if expected is not None:
+            assert mock_get.call_args.kwargs["params"]["q"] == search_term
+
+    @patch("trustshell.products.httpx.get")
+    def test_get_redhat_purl_from_generic(self, mock_get):
+        """purl~pkg:generic/Python with descendants returns items[0].descendants[0].purl[0] stripped to bare."""
+        with open("tests/testdata/pkg-generic-python-descendants.json") as f:
+            data = json.load(f)
+        mock_get.return_value.json.return_value = data
+        mock_get.return_value.raise_for_status = lambda: None
+        result = get_redhat_purl_from_generic("pkg:generic/Python", latest=True)
+        assert result == "pkg:rpm/redhat/python3.12"
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        assert call_args.kwargs["params"]["q"] == "purl~pkg:generic/Python"
+        assert call_args.kwargs["params"]["descendants"] == 10
+        assert call_args.kwargs["params"]["relationships"] == "ancestor_of"
+
+    @patch("trustshell.products.httpx.get")
+    def test_get_redhat_purl_from_generic_empty_descendants_returns_none(
+        self, mock_get
+    ):
+        """When items[0] has no descendants, get_redhat_purl_from_generic returns None."""
+        mock_get.return_value.json.return_value = {
+            "items": [{"purl": ["pkg:generic/Python@3.12.9"], "descendants": []}]
+        }
+        mock_get.return_value.raise_for_status = lambda: None
+        result = get_redhat_purl_from_generic("pkg:generic/Python", latest=True)
+        assert result is None
+
+    @patch("trustshell.products.httpx.get")
+    def test_search_term_www_python_org_resolves_to_redhat_purl(self, mock_get):
+        """Search 'www.python.org' -> generic then redhat PURL (same as trust-products input)."""
+        with open("tests/testdata/www.python.org-search.json") as f:
+            search_data = json.load(f)
+        with open("tests/testdata/pkg-generic-python-descendants.json") as f:
+            descendants_data = json.load(f)
+        mock_get.return_value.raise_for_status = lambda: None
+        mock_get.return_value.json.side_effect = [search_data, descendants_data]
+        generic = get_generic_purl_from_search_term("www.python.org", latest=True)
+        assert generic == "pkg:generic/Python"
+        redhat = get_redhat_purl_from_generic(generic, latest=True)
+        assert redhat == "pkg:rpm/redhat/python3.12"
+
+    @patch("trustshell.products.httpx.get")
+    def test_search_term_python_resolves_to_same_redhat_purl(self, mock_get):
+        """Search 'Python' -> same generic then redhat PURL as www.python.org."""
+        with open("tests/testdata/www.python.org-search.json") as f:
+            search_data = json.load(f)
+        with open("tests/testdata/pkg-generic-python-descendants.json") as f:
+            descendants_data = json.load(f)
+        mock_get.return_value.raise_for_status = lambda: None
+        mock_get.return_value.json.side_effect = [search_data, descendants_data]
+        generic = get_generic_purl_from_search_term("Python", latest=True)
+        assert generic == "pkg:generic/Python"
+        redhat = get_redhat_purl_from_generic(generic, latest=True)
+        assert redhat == "pkg:rpm/redhat/python3.12"
 
 
 def _check_node_names_at_depth(result, depth, expected):

--- a/tests/testdata/pkg-generic-python-descendants.json
+++ b/tests/testdata/pkg-generic-python-descendants.json
@@ -1,0 +1,226 @@
+{
+  "items": [
+    {
+      "sbom_id": "019cb365-97d8-75e3-9947-60ff8b33cec6",
+      "node_id": "pkg:generic/Python@3.12.9?download_url=https://pkgs.devel.redhat.com/repo/python3.12/Python-3.12.9.tar.xz.asc/sha512/b59251ca3a0a17c06ff7d165f6c025eb91127c80be0782642590f5c922297e0710544ac5a9ae977378e393f1c4861149576a0515af5ec0e54e6827c4010d544f/Python-3.12.9.tar.xz.asc&checksum=SHA-512:b59251ca3a0a17c06ff7d165f6c025eb91127c80be0782642590f5c922297e0710544ac5a9ae977378e393f1c4861149576a0515af5ec0e54e6827c4010d544f",
+      "purl": [
+        "pkg:generic/Python@3.12.9?checksum=SHA-512:b59251ca3a0a17c06ff7d165f6c025eb91127c80be0782642590f5c922297e0710544ac5a9ae977378e393f1c4861149576a0515af5ec0e54e6827c4010d544f&download_url=https://pkgs.devel.redhat.com/repo/python3.12/Python-3.12.9.tar.xz.asc/sha512/b59251ca3a0a17c06ff7d165f6c025eb91127c80be0782642590f5c922297e0710544ac5a9ae977378e393f1c4861149576a0515af5ec0e54e6827c4010d544f/Python-3.12.9.tar.xz.asc"
+      ],
+      "cpe": [],
+      "name": "Python",
+      "version": "3.12.9",
+      "published": "2025-02-11 00:19:34+00",
+      "document_id": "urn:uuid:6c113a71-21ac-4a39-b428-af3766230d69/1",
+      "product_name": "python3.12",
+      "product_version": "3.12.9-1.el9",
+      "descendants": [
+        {
+          "sbom_id": "019cb365-97d8-75e3-9947-60ff8b33cec6",
+          "node_id": "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src",
+          "purl": [
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-aarch64-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-s390x-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-ppc64le-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-s390x-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-x86_64-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-ppc64le-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-x86_64-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-aarch64-source-rpms__9_DOT_6"
+          ],
+          "cpe": [],
+          "name": "python3.12",
+          "version": "3.12.9-1.el9",
+          "published": "2025-02-11 00:19:34+00",
+          "document_id": "urn:uuid:6c113a71-21ac-4a39-b428-af3766230d69/1",
+          "product_name": "python3.12",
+          "product_version": "3.12.9-1.el9",
+          "relationship": "ancestor_of",
+          "descendants": []
+        }
+      ]
+    },
+    {
+      "sbom_id": "019cb365-97d8-75e3-9947-60ff8b33cec6",
+      "node_id": "pkg:generic/Python@3.12.9?download_url=https://pkgs.devel.redhat.com/repo/python3.12/Python-3.12.9.tar.xz/sha512/c840b14aa21e6a963d18c06ebaafb551d9c9a101b3866417e762fc4a2fde071a7a25fa257faba2956c7344bbc2413ed61690a712d26fba4d0dbeaa50e49b2574/Python-3.12.9.tar.xz&checksum=SHA-512:c840b14aa21e6a963d18c06ebaafb551d9c9a101b3866417e762fc4a2fde071a7a25fa257faba2956c7344bbc2413ed61690a712d26fba4d0dbeaa50e49b2574",
+      "purl": [
+        "pkg:generic/Python@3.12.9?checksum=SHA-512:c840b14aa21e6a963d18c06ebaafb551d9c9a101b3866417e762fc4a2fde071a7a25fa257faba2956c7344bbc2413ed61690a712d26fba4d0dbeaa50e49b2574&download_url=https://pkgs.devel.redhat.com/repo/python3.12/Python-3.12.9.tar.xz/sha512/c840b14aa21e6a963d18c06ebaafb551d9c9a101b3866417e762fc4a2fde071a7a25fa257faba2956c7344bbc2413ed61690a712d26fba4d0dbeaa50e49b2574/Python-3.12.9.tar.xz"
+      ],
+      "cpe": [],
+      "name": "Python",
+      "version": "3.12.9",
+      "published": "2025-02-11 00:19:34+00",
+      "document_id": "urn:uuid:6c113a71-21ac-4a39-b428-af3766230d69/1",
+      "product_name": "python3.12",
+      "product_version": "3.12.9-1.el9",
+      "descendants": [
+        {
+          "sbom_id": "019cb365-97d8-75e3-9947-60ff8b33cec6",
+          "node_id": "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src",
+          "purl": [
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-aarch64-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-s390x-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-ppc64le-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-s390x-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-x86_64-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_6",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-ppc64le-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-x86_64-source-rpms__9",
+            "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-aarch64-source-rpms__9_DOT_6"
+          ],
+          "cpe": [],
+          "name": "python3.12",
+          "version": "3.12.9-1.el9",
+          "published": "2025-02-11 00:19:34+00",
+          "document_id": "urn:uuid:6c113a71-21ac-4a39-b428-af3766230d69/1",
+          "product_name": "python3.12",
+          "product_version": "3.12.9-1.el9",
+          "relationship": "ancestor_of",
+          "descendants": []
+        }
+      ]
+    },
+    {
+      "sbom_id": "019cb365-97d8-75e3-9947-60ff8b33cec6",
+      "node_id": "pkg:generic/Python@3.12.9?download_url=https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tar.xz&checksum=SHA-256:7220835d9f90b37c006e9842a8dff4580aaca4318674f947302b8d28f3f81112",
+      "purl": [
+        "pkg:generic/Python@3.12.9?checksum=SHA-256:7220835d9f90b37c006e9842a8dff4580aaca4318674f947302b8d28f3f81112&download_url=https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tar.xz"
+      ],
+      "cpe": [],
+      "name": "Python",
+      "version": "3.12.9",
+      "published": "2025-02-11 00:19:34+00",
+      "document_id": "urn:uuid:6c113a71-21ac-4a39-b428-af3766230d69/1",
+      "product_name": "python3.12",
+      "product_version": "3.12.9-1.el9",
+      "descendants": [
+        {
+          "sbom_id": "019cb365-97d8-75e3-9947-60ff8b33cec6",
+          "node_id": "pkg:generic/Python@3.12.9?download_url=https://pkgs.devel.redhat.com/repo/python3.12/Python-3.12.9.tar.xz/sha512/c840b14aa21e6a963d18c06ebaafb551d9c9a101b3866417e762fc4a2fde071a7a25fa257faba2956c7344bbc2413ed61690a712d26fba4d0dbeaa50e49b2574/Python-3.12.9.tar.xz&checksum=SHA-512:c840b14aa21e6a963d18c06ebaafb551d9c9a101b3866417e762fc4a2fde071a7a25fa257faba2956c7344bbc2413ed61690a712d26fba4d0dbeaa50e49b2574",
+          "purl": [
+            "pkg:generic/Python@3.12.9?checksum=SHA-512:c840b14aa21e6a963d18c06ebaafb551d9c9a101b3866417e762fc4a2fde071a7a25fa257faba2956c7344bbc2413ed61690a712d26fba4d0dbeaa50e49b2574&download_url=https://pkgs.devel.redhat.com/repo/python3.12/Python-3.12.9.tar.xz/sha512/c840b14aa21e6a963d18c06ebaafb551d9c9a101b3866417e762fc4a2fde071a7a25fa257faba2956c7344bbc2413ed61690a712d26fba4d0dbeaa50e49b2574/Python-3.12.9.tar.xz"
+          ],
+          "cpe": [],
+          "name": "Python",
+          "version": "3.12.9",
+          "published": "2025-02-11 00:19:34+00",
+          "document_id": "urn:uuid:6c113a71-21ac-4a39-b428-af3766230d69/1",
+          "product_name": "python3.12",
+          "product_version": "3.12.9-1.el9",
+          "relationship": "ancestor_of",
+          "descendants": [
+            {
+              "sbom_id": "019cb365-97d8-75e3-9947-60ff8b33cec6",
+              "node_id": "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src",
+              "purl": [
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-aarch64-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-s390x-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-ppc64le-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-s390x-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-x86_64-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-ppc64le-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-x86_64-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-aarch64-source-rpms__9_DOT_6"
+              ],
+              "cpe": [],
+              "name": "python3.12",
+              "version": "3.12.9-1.el9",
+              "published": "2025-02-11 00:19:34+00",
+              "document_id": "urn:uuid:6c113a71-21ac-4a39-b428-af3766230d69/1",
+              "product_name": "python3.12",
+              "product_version": "3.12.9-1.el9",
+              "relationship": "ancestor_of",
+              "descendants": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "sbom_id": "019cb365-97d8-75e3-9947-60ff8b33cec6",
+      "node_id": "pkg:generic/Python@3.12.9?download_url=https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tar.xz.asc&checksum=SHA-256:5ec436571ef013ef774145f4dff424109c13fc0bfe45542e6ae0871e369ed7d9",
+      "purl": [
+        "pkg:generic/Python@3.12.9?checksum=SHA-256:5ec436571ef013ef774145f4dff424109c13fc0bfe45542e6ae0871e369ed7d9&download_url=https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tar.xz.asc"
+      ],
+      "cpe": [],
+      "name": "Python",
+      "version": "3.12.9",
+      "published": "2025-02-11 00:19:34+00",
+      "document_id": "urn:uuid:6c113a71-21ac-4a39-b428-af3766230d69/1",
+      "product_name": "python3.12",
+      "product_version": "3.12.9-1.el9",
+      "descendants": [
+        {
+          "sbom_id": "019cb365-97d8-75e3-9947-60ff8b33cec6",
+          "node_id": "pkg:generic/Python@3.12.9?download_url=https://pkgs.devel.redhat.com/repo/python3.12/Python-3.12.9.tar.xz.asc/sha512/b59251ca3a0a17c06ff7d165f6c025eb91127c80be0782642590f5c922297e0710544ac5a9ae977378e393f1c4861149576a0515af5ec0e54e6827c4010d544f/Python-3.12.9.tar.xz.asc&checksum=SHA-512:b59251ca3a0a17c06ff7d165f6c025eb91127c80be0782642590f5c922297e0710544ac5a9ae977378e393f1c4861149576a0515af5ec0e54e6827c4010d544f",
+          "purl": [
+            "pkg:generic/Python@3.12.9?checksum=SHA-512:b59251ca3a0a17c06ff7d165f6c025eb91127c80be0782642590f5c922297e0710544ac5a9ae977378e393f1c4861149576a0515af5ec0e54e6827c4010d544f&download_url=https://pkgs.devel.redhat.com/repo/python3.12/Python-3.12.9.tar.xz.asc/sha512/b59251ca3a0a17c06ff7d165f6c025eb91127c80be0782642590f5c922297e0710544ac5a9ae977378e393f1c4861149576a0515af5ec0e54e6827c4010d544f/Python-3.12.9.tar.xz.asc"
+          ],
+          "cpe": [],
+          "name": "Python",
+          "version": "3.12.9",
+          "published": "2025-02-11 00:19:34+00",
+          "document_id": "urn:uuid:6c113a71-21ac-4a39-b428-af3766230d69/1",
+          "product_name": "python3.12",
+          "product_version": "3.12.9-1.el9",
+          "relationship": "ancestor_of",
+          "descendants": [
+            {
+              "sbom_id": "019cb365-97d8-75e3-9947-60ff8b33cec6",
+              "node_id": "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src",
+              "purl": [
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-aarch64-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-aarch64-appstream-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-s390x-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-ppc64le-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-s390x-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-x86_64-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-ppc64le-appstream-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-x86_64-appstream-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=rhel-9-for-s390x-appstream-source-rpms__9_DOT_6",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-ppc64le-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-x86_64-source-rpms__9",
+                "pkg:rpm/redhat/python3.12@3.12.9-1.el9?arch=src&repository_id=codeready-builder-for-rhel-9-aarch64-source-rpms__9_DOT_6"
+              ],
+              "cpe": [],
+              "name": "python3.12",
+              "version": "3.12.9-1.el9",
+              "published": "2025-02-11 00:19:34+00",
+              "document_id": "urn:uuid:6c113a71-21ac-4a39-b428-af3766230d69/1",
+              "product_name": "python3.12",
+              "product_version": "3.12.9-1.el9",
+              "relationship": "ancestor_of",
+              "descendants": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/testdata/www.python.org-search.json
+++ b/tests/testdata/www.python.org-search.json
@@ -1,0 +1,32 @@
+{
+  "items": [
+  {
+    "sbom_id": "019cb365-97d8-75e3-9947-60ff8b33cec6",
+    "node_id": "pkg:generic/Python@3.12.9?download_url=https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tar.xz&checksum=SHA-256:7220835d9f90b37c006e9842a8dff4580aaca4318674f947302b8d28f3f81112",
+    "purl": [
+      "pkg:generic/Python@3.12.9?checksum=SHA-256:7220835d9f90b37c006e9842a8dff4580aaca4318674f947302b8d28f3f81112&download_url=https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tar.xz"
+    ],
+    "cpe": [],
+    "name": "Python",
+    "version": "3.12.9",
+    "published": "2025-02-11 00:19:34+00",
+    "document_id": "urn:uuid:6c113a71-21ac-4a39-b428-af3766230d69/1",
+    "product_name": "python3.12",
+    "product_version": "3.12.9-1.el9"
+  },
+  {
+    "sbom_id": "019cb365-97d8-75e3-9947-60ff8b33cec6",
+    "node_id": "pkg:generic/Python@3.12.9?download_url=https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tar.xz.asc&checksum=SHA-256:5ec436571ef013ef774145f4dff424109c13fc0bfe45542e6ae0871e369ed7d9",
+    "purl": [
+      "pkg:generic/Python@3.12.9?checksum=SHA-256:5ec436571ef013ef774145f4dff424109c13fc0bfe45542e6ae0871e369ed7d9&download_url=https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tar.xz.asc"
+    ],
+    "cpe": [],
+    "name": "Python",
+    "version": "3.12.9",
+    "published": "2025-02-11 00:19:34+00",
+    "document_id": "urn:uuid:6c113a71-21ac-4a39-b428-af3766230d69/1",
+    "product_name": "python3.12",
+    "product_version": "3.12.9-1.el9"
+  }
+  ]
+}


### PR DESCRIPTION
This commit expands the way the trust-products command works by not only accepting PURLs as input but also free-form search terms.

Closes PSDEVOPS-4346